### PR TITLE
Primitives

### DIFF
--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -38,7 +38,7 @@ module Rattletrap
   , module Rattletrap.Version
   , module Rattletrap.Word32
   , module Rattletrap.Word64
-  , module Rattletrap.Word8
+  , module Rattletrap.Primitive.Word8
   ) where
 
 import Rattletrap.ActorMap
@@ -81,4 +81,4 @@ import Rattletrap.Primitive.Vector
 import Rattletrap.Version
 import Rattletrap.Word32
 import Rattletrap.Word64
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -32,7 +32,7 @@ module Rattletrap
   , module Rattletrap.Replication
   , module Rattletrap.ReplicationValue
   , module Rattletrap.Section
-  , module Rattletrap.Text
+  , module Rattletrap.Primitive.Text
   , module Rattletrap.Utility
   , module Rattletrap.Vector
   , module Rattletrap.Version
@@ -75,7 +75,7 @@ import Rattletrap.Replay
 import Rattletrap.Replication
 import Rattletrap.ReplicationValue
 import Rattletrap.Section
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Utility
 import Rattletrap.Vector
 import Rattletrap.Version

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -37,7 +37,7 @@ module Rattletrap
   , module Rattletrap.Primitive.Vector
   , module Rattletrap.Version
   , module Rattletrap.Primitive.Word32
-  , module Rattletrap.Word64
+  , module Rattletrap.Primitive.Word64
   , module Rattletrap.Primitive.Word8
   ) where
 
@@ -80,5 +80,5 @@ import Rattletrap.Utility
 import Rattletrap.Primitive.Vector
 import Rattletrap.Version
 import Rattletrap.Primitive.Word32
-import Rattletrap.Word64
+import Rattletrap.Primitive.Word64
 import Rattletrap.Primitive.Word8

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -34,7 +34,7 @@ module Rattletrap
   , module Rattletrap.Section
   , module Rattletrap.Primitive.Text
   , module Rattletrap.Utility
-  , module Rattletrap.Vector
+  , module Rattletrap.Primitive.Vector
   , module Rattletrap.Version
   , module Rattletrap.Word32
   , module Rattletrap.Word64
@@ -77,7 +77,7 @@ import Rattletrap.ReplicationValue
 import Rattletrap.Section
 import Rattletrap.Primitive.Text
 import Rattletrap.Utility
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 import Rattletrap.Version
 import Rattletrap.Word32
 import Rattletrap.Word64

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -8,7 +8,7 @@ module Rattletrap
   , module Rattletrap.ClassAttributeMap
   , module Rattletrap.ClassMapping
   , module Rattletrap.Primitive.CompressedWord
-  , module Rattletrap.CompressedWordVector
+  , module Rattletrap.Primitive.CompressedWordVector
   , module Rattletrap.Content
   , module Rattletrap.Crc
   , module Rattletrap.Data
@@ -50,7 +50,7 @@ import Rattletrap.Cache
 import Rattletrap.ClassAttributeMap
 import Rattletrap.ClassMapping
 import Rattletrap.Primitive.CompressedWord
-import Rattletrap.CompressedWordVector
+import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Crc
 import Rattletrap.Data

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -7,7 +7,7 @@ module Rattletrap
   , module Rattletrap.Cache
   , module Rattletrap.ClassAttributeMap
   , module Rattletrap.ClassMapping
-  , module Rattletrap.CompressedWord
+  , module Rattletrap.Primitive.CompressedWord
   , module Rattletrap.CompressedWordVector
   , module Rattletrap.Content
   , module Rattletrap.Crc
@@ -49,7 +49,7 @@ import Rattletrap.AttributeValueType
 import Rattletrap.Cache
 import Rattletrap.ClassAttributeMap
 import Rattletrap.ClassMapping
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Crc

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -21,7 +21,7 @@ module Rattletrap
   , module Rattletrap.Primitive.Int8
   , module Rattletrap.Primitive.Int8Vector
   , module Rattletrap.KeyFrame
-  , module Rattletrap.List
+  , module Rattletrap.Primitive.List
   , module Rattletrap.Main
   , module Rattletrap.Mark
   , module Rattletrap.Message
@@ -64,7 +64,7 @@ import Rattletrap.Primitive.Int8
 import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Json ()
 import Rattletrap.KeyFrame
-import Rattletrap.List
+import Rattletrap.Primitive.List
 import Rattletrap.Main
 import Rattletrap.Mark
 import Rattletrap.Message

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -17,7 +17,7 @@ module Rattletrap
   , module Rattletrap.Frame
   , module Rattletrap.Header
   , module Rattletrap.Initialization
-  , module Rattletrap.Int32
+  , module Rattletrap.Primitive.Int32
   , module Rattletrap.Primitive.Int8
   , module Rattletrap.Primitive.Int8Vector
   , module Rattletrap.KeyFrame
@@ -59,7 +59,7 @@ import Rattletrap.Primitive.Float32
 import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.Int8
 import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Json ()

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -13,7 +13,7 @@ module Rattletrap
   , module Rattletrap.Crc
   , module Rattletrap.Data
   , module Rattletrap.Primitive.Dictionary
-  , module Rattletrap.Float32
+  , module Rattletrap.Primitive.Float32
   , module Rattletrap.Frame
   , module Rattletrap.Header
   , module Rattletrap.Initialization
@@ -55,7 +55,7 @@ import Rattletrap.Content
 import Rattletrap.Crc
 import Rattletrap.Data
 import Rattletrap.Primitive.Dictionary
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -18,7 +18,7 @@ module Rattletrap
   , module Rattletrap.Header
   , module Rattletrap.Initialization
   , module Rattletrap.Int32
-  , module Rattletrap.Int8
+  , module Rattletrap.Primitive.Int8
   , module Rattletrap.Int8Vector
   , module Rattletrap.KeyFrame
   , module Rattletrap.List
@@ -60,7 +60,7 @@ import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization
 import Rattletrap.Int32
-import Rattletrap.Int8
+import Rattletrap.Primitive.Int8
 import Rattletrap.Int8Vector
 import Rattletrap.Json ()
 import Rattletrap.KeyFrame

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -36,7 +36,7 @@ module Rattletrap
   , module Rattletrap.Utility
   , module Rattletrap.Primitive.Vector
   , module Rattletrap.Version
-  , module Rattletrap.Word32
+  , module Rattletrap.Primitive.Word32
   , module Rattletrap.Word64
   , module Rattletrap.Primitive.Word8
   ) where
@@ -79,6 +79,6 @@ import Rattletrap.Primitive.Text
 import Rattletrap.Utility
 import Rattletrap.Primitive.Vector
 import Rattletrap.Version
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 import Rattletrap.Word64
 import Rattletrap.Primitive.Word8

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -12,7 +12,7 @@ module Rattletrap
   , module Rattletrap.Content
   , module Rattletrap.Crc
   , module Rattletrap.Data
-  , module Rattletrap.Dictionary
+  , module Rattletrap.Primitive.Dictionary
   , module Rattletrap.Float32
   , module Rattletrap.Frame
   , module Rattletrap.Header
@@ -54,7 +54,7 @@ import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Crc
 import Rattletrap.Data
-import Rattletrap.Dictionary
+import Rattletrap.Primitive.Dictionary
 import Rattletrap.Float32
 import Rattletrap.Frame
 import Rattletrap.Header

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -19,7 +19,7 @@ module Rattletrap
   , module Rattletrap.Initialization
   , module Rattletrap.Int32
   , module Rattletrap.Primitive.Int8
-  , module Rattletrap.Int8Vector
+  , module Rattletrap.Primitive.Int8Vector
   , module Rattletrap.KeyFrame
   , module Rattletrap.List
   , module Rattletrap.Main
@@ -61,7 +61,7 @@ import Rattletrap.Header
 import Rattletrap.Initialization
 import Rattletrap.Int32
 import Rattletrap.Primitive.Int8
-import Rattletrap.Int8Vector
+import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Json ()
 import Rattletrap.KeyFrame
 import Rattletrap.List

--- a/library/Rattletrap.hs
+++ b/library/Rattletrap.hs
@@ -7,24 +7,17 @@ module Rattletrap
   , module Rattletrap.Cache
   , module Rattletrap.ClassAttributeMap
   , module Rattletrap.ClassMapping
-  , module Rattletrap.Primitive.CompressedWord
-  , module Rattletrap.Primitive.CompressedWordVector
   , module Rattletrap.Content
   , module Rattletrap.Crc
   , module Rattletrap.Data
-  , module Rattletrap.Primitive.Dictionary
-  , module Rattletrap.Primitive.Float32
   , module Rattletrap.Frame
   , module Rattletrap.Header
   , module Rattletrap.Initialization
-  , module Rattletrap.Primitive.Int32
-  , module Rattletrap.Primitive.Int8
-  , module Rattletrap.Primitive.Int8Vector
   , module Rattletrap.KeyFrame
-  , module Rattletrap.Primitive.List
   , module Rattletrap.Main
   , module Rattletrap.Mark
   , module Rattletrap.Message
+  , module Rattletrap.Primitive
   , module Rattletrap.Property
   , module Rattletrap.PropertyValue
   , module Rattletrap.RemoteId
@@ -32,13 +25,8 @@ module Rattletrap
   , module Rattletrap.Replication
   , module Rattletrap.ReplicationValue
   , module Rattletrap.Section
-  , module Rattletrap.Primitive.Text
   , module Rattletrap.Utility
-  , module Rattletrap.Primitive.Vector
   , module Rattletrap.Version
-  , module Rattletrap.Primitive.Word32
-  , module Rattletrap.Primitive.Word64
-  , module Rattletrap.Primitive.Word8
   ) where
 
 import Rattletrap.ActorMap
@@ -49,25 +37,18 @@ import Rattletrap.AttributeValueType
 import Rattletrap.Cache
 import Rattletrap.ClassAttributeMap
 import Rattletrap.ClassMapping
-import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Crc
 import Rattletrap.Data
-import Rattletrap.Primitive.Dictionary
-import Rattletrap.Primitive.Float32
 import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization
-import Rattletrap.Primitive.Int32
-import Rattletrap.Primitive.Int8
-import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Json ()
 import Rattletrap.KeyFrame
-import Rattletrap.Primitive.List
 import Rattletrap.Main
 import Rattletrap.Mark
 import Rattletrap.Message
+import Rattletrap.Primitive
 import Rattletrap.Property
 import Rattletrap.PropertyValue
 import Rattletrap.RemoteId
@@ -75,10 +56,5 @@ import Rattletrap.Replay
 import Rattletrap.Replication
 import Rattletrap.ReplicationValue
 import Rattletrap.Section
-import Rattletrap.Primitive.Text
 import Rattletrap.Utility
-import Rattletrap.Primitive.Vector
 import Rattletrap.Version
-import Rattletrap.Primitive.Word32
-import Rattletrap.Primitive.Word64
-import Rattletrap.Primitive.Word8

--- a/library/Rattletrap/ActorMap.hs
+++ b/library/Rattletrap/ActorMap.hs
@@ -1,6 +1,6 @@
 module Rattletrap.ActorMap where
 
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Word32
 
 import qualified Data.Map as Map

--- a/library/Rattletrap/ActorMap.hs
+++ b/library/Rattletrap/ActorMap.hs
@@ -1,7 +1,7 @@
 module Rattletrap.ActorMap where
 
 import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Map as Map
 

--- a/library/Rattletrap/ActorMap.hs
+++ b/library/Rattletrap/ActorMap.hs
@@ -1,7 +1,6 @@
 module Rattletrap.ActorMap where
 
-import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Map as Map
 

--- a/library/Rattletrap/Attribute.hs
+++ b/library/Rattletrap/Attribute.hs
@@ -3,7 +3,7 @@ module Rattletrap.Attribute where
 import Rattletrap.ActorMap
 import Rattletrap.AttributeValue
 import Rattletrap.ClassAttributeMap
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Attribute.hs
+++ b/library/Rattletrap/Attribute.hs
@@ -3,7 +3,7 @@ module Rattletrap.Attribute where
 import Rattletrap.ActorMap
 import Rattletrap.AttributeValue
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Primitive.CompressedWord
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeMapping.hs
+++ b/library/Rattletrap/AttributeMapping.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeMapping where
 
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/AttributeMapping.hs
+++ b/library/Rattletrap/AttributeMapping.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeMapping where
 
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/AttributeValue.hs
+++ b/library/Rattletrap/AttributeValue.hs
@@ -58,7 +58,7 @@ import Rattletrap.AttributeValue.UniqueId
 import Rattletrap.AttributeValue.WeldedInfo
 import Rattletrap.AttributeValueType
 import Rattletrap.Data
-import Rattletrap.Primitive.Text
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue.hs
+++ b/library/Rattletrap/AttributeValue.hs
@@ -58,7 +58,7 @@ import Rattletrap.AttributeValue.UniqueId
 import Rattletrap.AttributeValue.WeldedInfo
 import Rattletrap.AttributeValueType
 import Rattletrap.Data
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Byte.hs
+++ b/library/Rattletrap/AttributeValue/Byte.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Byte where
 
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Byte.hs
+++ b/library/Rattletrap/AttributeValue/Byte.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Byte where
 
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/CamSettings.hs
+++ b/library/Rattletrap/AttributeValue/CamSettings.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.CamSettings where
 
-import Rattletrap.Primitive.Float32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/CamSettings.hs
+++ b/library/Rattletrap/AttributeValue/CamSettings.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.CamSettings where
 
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/ClubColors.hs
+++ b/library/Rattletrap/AttributeValue/ClubColors.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.ClubColors where
 
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/ClubColors.hs
+++ b/library/Rattletrap/AttributeValue/ClubColors.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.ClubColors where
 
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Demolish.hs
+++ b/library/Rattletrap/AttributeValue/Demolish.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.Demolish where
 
-import Rattletrap.Primitive.Vector
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Demolish.hs
+++ b/library/Rattletrap/AttributeValue/Demolish.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Demolish where
 
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 import Rattletrap.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/Demolish.hs
+++ b/library/Rattletrap/AttributeValue/Demolish.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.Demolish where
 
 import Rattletrap.Primitive.Vector
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Explosion.hs
+++ b/library/Rattletrap/AttributeValue/Explosion.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Explosion where
 
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/Explosion.hs
+++ b/library/Rattletrap/AttributeValue/Explosion.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.Explosion where
 
-import Rattletrap.Primitive.Int32
-import Rattletrap.Primitive.Vector
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Explosion.hs
+++ b/library/Rattletrap/AttributeValue/Explosion.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.Explosion where
 
 import Rattletrap.Primitive.Int32
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/FlaggedInt.hs
+++ b/library/Rattletrap/AttributeValue/FlaggedInt.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.FlaggedInt where
 
-import Rattletrap.Primitive.Int32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/FlaggedInt.hs
+++ b/library/Rattletrap/AttributeValue/FlaggedInt.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.FlaggedInt where
 
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Float.hs
+++ b/library/Rattletrap/AttributeValue/Float.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Float where
 
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Float.hs
+++ b/library/Rattletrap/AttributeValue/Float.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Float where
 
-import Rattletrap.Primitive.Float32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Int.hs
+++ b/library/Rattletrap/AttributeValue/Int.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Int where
 
-import Rattletrap.Primitive.Int32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Int.hs
+++ b/library/Rattletrap/AttributeValue/Int.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Int where
 
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Loadout.hs
+++ b/library/Rattletrap/AttributeValue/Loadout.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Loadout where
 
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/Loadout.hs
+++ b/library/Rattletrap/AttributeValue/Loadout.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.Loadout where
 
 import Rattletrap.Word32
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Loadout.hs
+++ b/library/Rattletrap/AttributeValue/Loadout.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.Loadout where
 
-import Rattletrap.Primitive.Word32
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/LoadoutOnline.hs
+++ b/library/Rattletrap/AttributeValue/LoadoutOnline.hs
@@ -1,8 +1,6 @@
 module Rattletrap.AttributeValue.LoadoutOnline where
 
-import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Primitive.Word32
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Control.Monad as Monad
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/LoadoutOnline.hs
+++ b/library/Rattletrap/AttributeValue/LoadoutOnline.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.LoadoutOnline where
 
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Word32
 import Rattletrap.Word8
 

--- a/library/Rattletrap/AttributeValue/LoadoutOnline.hs
+++ b/library/Rattletrap/AttributeValue/LoadoutOnline.hs
@@ -2,7 +2,7 @@ module Rattletrap.AttributeValue.LoadoutOnline where
 
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Word32
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Control.Monad as Monad
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/LoadoutOnline.hs
+++ b/library/Rattletrap/AttributeValue/LoadoutOnline.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.LoadoutOnline where
 
 import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 import Rattletrap.Primitive.Word8
 
 import qualified Control.Monad as Monad

--- a/library/Rattletrap/AttributeValue/Location.hs
+++ b/library/Rattletrap/AttributeValue/Location.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Location where
 
-import Rattletrap.Primitive.Vector
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Location.hs
+++ b/library/Rattletrap/AttributeValue/Location.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Location where
 
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/MusicStinger.hs
+++ b/library/Rattletrap/AttributeValue/MusicStinger.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.MusicStinger where
 
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/MusicStinger.hs
+++ b/library/Rattletrap/AttributeValue/MusicStinger.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.MusicStinger where
 
-import Rattletrap.Primitive.Word32
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/MusicStinger.hs
+++ b/library/Rattletrap/AttributeValue/MusicStinger.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.MusicStinger where
 
 import Rattletrap.Word32
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/PartyLeader.hs
+++ b/library/Rattletrap/AttributeValue/PartyLeader.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.PartyLeader where
 
+import Rattletrap.Primitive
 import Rattletrap.RemoteId
-import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/PartyLeader.hs
+++ b/library/Rattletrap/AttributeValue/PartyLeader.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.PartyLeader where
 
 import Rattletrap.RemoteId
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Pickup.hs
+++ b/library/Rattletrap/AttributeValue/Pickup.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Pickup where
 
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Pickup.hs
+++ b/library/Rattletrap/AttributeValue/Pickup.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.Pickup where
 
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/PrivateMatchSettings.hs
+++ b/library/Rattletrap/AttributeValue/PrivateMatchSettings.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.PrivateMatchSettings where
 
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/PrivateMatchSettings.hs
+++ b/library/Rattletrap/AttributeValue/PrivateMatchSettings.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.PrivateMatchSettings where
 
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/PrivateMatchSettings.hs
+++ b/library/Rattletrap/AttributeValue/PrivateMatchSettings.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.PrivateMatchSettings where
 
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/QWord.hs
+++ b/library/Rattletrap/AttributeValue/QWord.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.QWord where
 
-import Rattletrap.Primitive.Word64
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/QWord.hs
+++ b/library/Rattletrap/AttributeValue/QWord.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.QWord where
 
-import Rattletrap.Word64
+import Rattletrap.Primitive.Word64
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Reservation.hs
+++ b/library/Rattletrap/AttributeValue/Reservation.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.Reservation where
 
 import Rattletrap.AttributeValue.UniqueId
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Text
 import Rattletrap.Word8
 

--- a/library/Rattletrap/AttributeValue/Reservation.hs
+++ b/library/Rattletrap/AttributeValue/Reservation.hs
@@ -2,7 +2,7 @@ module Rattletrap.AttributeValue.Reservation where
 
 import Rattletrap.AttributeValue.UniqueId
 import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/Reservation.hs
+++ b/library/Rattletrap/AttributeValue/Reservation.hs
@@ -3,7 +3,7 @@ module Rattletrap.AttributeValue.Reservation where
 import Rattletrap.AttributeValue.UniqueId
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Primitive.Text
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/Reservation.hs
+++ b/library/Rattletrap/AttributeValue/Reservation.hs
@@ -1,9 +1,7 @@
 module Rattletrap.AttributeValue.Reservation where
 
 import Rattletrap.AttributeValue.UniqueId
-import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/RigidBodyState.hs
+++ b/library/Rattletrap/AttributeValue/RigidBodyState.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.RigidBodyState where
 
 import Rattletrap.Primitive.CompressedWordVector
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/RigidBodyState.hs
+++ b/library/Rattletrap/AttributeValue/RigidBodyState.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.RigidBodyState where
 
-import Rattletrap.CompressedWordVector
+import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/RigidBodyState.hs
+++ b/library/Rattletrap/AttributeValue/RigidBodyState.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.RigidBodyState where
 
-import Rattletrap.Primitive.CompressedWordVector
-import Rattletrap.Primitive.Vector
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/String.hs
+++ b/library/Rattletrap/AttributeValue/String.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.String where
 
-import Rattletrap.Primitive.Text
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/String.hs
+++ b/library/Rattletrap/AttributeValue/String.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.String where
 
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/TeamPaint.hs
+++ b/library/Rattletrap/AttributeValue/TeamPaint.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.TeamPaint where
 
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/TeamPaint.hs
+++ b/library/Rattletrap/AttributeValue/TeamPaint.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.TeamPaint where
 
 import Rattletrap.Word32
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/TeamPaint.hs
+++ b/library/Rattletrap/AttributeValue/TeamPaint.hs
@@ -1,7 +1,6 @@
 module Rattletrap.AttributeValue.TeamPaint where
 
-import Rattletrap.Primitive.Word32
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/UniqueId.hs
+++ b/library/Rattletrap/AttributeValue/UniqueId.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.UniqueId where
 
 import Rattletrap.RemoteId
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/UniqueId.hs
+++ b/library/Rattletrap/AttributeValue/UniqueId.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.UniqueId where
 
+import Rattletrap.Primitive
 import Rattletrap.RemoteId
-import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/WeldedInfo.hs
+++ b/library/Rattletrap/AttributeValue/WeldedInfo.hs
@@ -2,7 +2,7 @@ module Rattletrap.AttributeValue.WeldedInfo where
 
 import Rattletrap.Primitive.Float32
 import Rattletrap.Int32
-import Rattletrap.Int8Vector
+import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/AttributeValue/WeldedInfo.hs
+++ b/library/Rattletrap/AttributeValue/WeldedInfo.hs
@@ -1,7 +1,7 @@
 module Rattletrap.AttributeValue.WeldedInfo where
 
 import Rattletrap.Primitive.Float32
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Vector
 

--- a/library/Rattletrap/AttributeValue/WeldedInfo.hs
+++ b/library/Rattletrap/AttributeValue/WeldedInfo.hs
@@ -1,9 +1,6 @@
 module Rattletrap.AttributeValue.WeldedInfo where
 
-import Rattletrap.Primitive.Float32
-import Rattletrap.Primitive.Int32
-import Rattletrap.Primitive.Int8Vector
-import Rattletrap.Primitive.Vector
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/WeldedInfo.hs
+++ b/library/Rattletrap/AttributeValue/WeldedInfo.hs
@@ -3,7 +3,7 @@ module Rattletrap.AttributeValue.WeldedInfo where
 import Rattletrap.Primitive.Float32
 import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.Int8Vector
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/AttributeValue/WeldedInfo.hs
+++ b/library/Rattletrap/AttributeValue/WeldedInfo.hs
@@ -1,6 +1,6 @@
 module Rattletrap.AttributeValue.WeldedInfo where
 
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 import Rattletrap.Int32
 import Rattletrap.Int8Vector
 import Rattletrap.Vector

--- a/library/Rattletrap/Cache.hs
+++ b/library/Rattletrap/Cache.hs
@@ -2,7 +2,7 @@ module Rattletrap.Cache where
 
 import Rattletrap.AttributeMapping
 import Rattletrap.Primitive.List
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Cache.hs
+++ b/library/Rattletrap/Cache.hs
@@ -1,8 +1,7 @@
 module Rattletrap.Cache where
 
 import Rattletrap.AttributeMapping
-import Rattletrap.Primitive.List
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Cache.hs
+++ b/library/Rattletrap/Cache.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Cache where
 
 import Rattletrap.AttributeMapping
-import Rattletrap.List
+import Rattletrap.Primitive.List
 import Rattletrap.Word32
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/ClassAttributeMap.hs
+++ b/library/Rattletrap/ClassAttributeMap.hs
@@ -9,7 +9,7 @@ import Rattletrap.Data
 import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.List
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Bimap as Bimap
 import qualified Data.List as List

--- a/library/Rattletrap/ClassAttributeMap.hs
+++ b/library/Rattletrap/ClassAttributeMap.hs
@@ -8,7 +8,7 @@ import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Data
 import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.List
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Bimap as Bimap

--- a/library/Rattletrap/ClassAttributeMap.hs
+++ b/library/Rattletrap/ClassAttributeMap.hs
@@ -6,7 +6,7 @@ import Rattletrap.Cache
 import Rattletrap.ClassMapping
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Data
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.List
 import Rattletrap.Text
 import Rattletrap.Word32

--- a/library/Rattletrap/ClassAttributeMap.hs
+++ b/library/Rattletrap/ClassAttributeMap.hs
@@ -4,12 +4,8 @@ import Rattletrap.ActorMap
 import Rattletrap.AttributeMapping
 import Rattletrap.Cache
 import Rattletrap.ClassMapping
-import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Data
-import Rattletrap.Primitive.Int32
-import Rattletrap.Primitive.List
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Bimap as Bimap
 import qualified Data.List as List

--- a/library/Rattletrap/ClassAttributeMap.hs
+++ b/library/Rattletrap/ClassAttributeMap.hs
@@ -4,7 +4,7 @@ import Rattletrap.ActorMap
 import Rattletrap.AttributeMapping
 import Rattletrap.Cache
 import Rattletrap.ClassMapping
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Data
 import Rattletrap.Int32
 import Rattletrap.List

--- a/library/Rattletrap/ClassAttributeMap.hs
+++ b/library/Rattletrap/ClassAttributeMap.hs
@@ -7,7 +7,7 @@ import Rattletrap.ClassMapping
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Data
 import Rattletrap.Primitive.Int32
-import Rattletrap.List
+import Rattletrap.Primitive.List
 import Rattletrap.Text
 import Rattletrap.Word32
 

--- a/library/Rattletrap/ClassMapping.hs
+++ b/library/Rattletrap/ClassMapping.hs
@@ -1,7 +1,7 @@
 module Rattletrap.ClassMapping where
 
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/ClassMapping.hs
+++ b/library/Rattletrap/ClassMapping.hs
@@ -1,6 +1,6 @@
 module Rattletrap.ClassMapping where
 
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/ClassMapping.hs
+++ b/library/Rattletrap/ClassMapping.hs
@@ -1,7 +1,6 @@
 module Rattletrap.ClassMapping where
 
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/CompressedWordVector.hs
+++ b/library/Rattletrap/CompressedWordVector.hs
@@ -1,6 +1,6 @@
 module Rattletrap.CompressedWordVector where
 
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Content.hs
+++ b/library/Rattletrap/Content.hs
@@ -6,7 +6,7 @@ import Rattletrap.ClassAttributeMap
 import Rattletrap.ClassMapping
 import Rattletrap.Frame
 import Rattletrap.KeyFrame
-import Rattletrap.List
+import Rattletrap.Primitive.List
 import Rattletrap.Mark
 import Rattletrap.Message
 import Rattletrap.Text

--- a/library/Rattletrap/Content.hs
+++ b/library/Rattletrap/Content.hs
@@ -9,7 +9,7 @@ import Rattletrap.KeyFrame
 import Rattletrap.Primitive.List
 import Rattletrap.Mark
 import Rattletrap.Message
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Utility
 import Rattletrap.Word32
 

--- a/library/Rattletrap/Content.hs
+++ b/library/Rattletrap/Content.hs
@@ -11,7 +11,7 @@ import Rattletrap.Mark
 import Rattletrap.Message
 import Rattletrap.Primitive.Text
 import Rattletrap.Utility
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/Content.hs
+++ b/library/Rattletrap/Content.hs
@@ -6,12 +6,10 @@ import Rattletrap.ClassAttributeMap
 import Rattletrap.ClassMapping
 import Rattletrap.Frame
 import Rattletrap.KeyFrame
-import Rattletrap.Primitive.List
 import Rattletrap.Mark
 import Rattletrap.Message
-import Rattletrap.Primitive.Text
+import Rattletrap.Primitive
 import Rattletrap.Utility
-import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/Frame.hs
+++ b/library/Rattletrap/Frame.hs
@@ -2,7 +2,7 @@ module Rattletrap.Frame where
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Primitive.Float32
+import Rattletrap.Primitive
 import Rattletrap.Replication
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/Frame.hs
+++ b/library/Rattletrap/Frame.hs
@@ -2,7 +2,7 @@ module Rattletrap.Frame where
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 import Rattletrap.Replication
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/Header.hs
+++ b/library/Rattletrap/Header.hs
@@ -1,11 +1,8 @@
 module Rattletrap.Header where
 
-import Rattletrap.Primitive.Dictionary
-import Rattletrap.Primitive.Int32
+import Rattletrap.Primitive
 import Rattletrap.Property
 import Rattletrap.PropertyValue
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Header.hs
+++ b/library/Rattletrap/Header.hs
@@ -4,7 +4,7 @@ import Rattletrap.Primitive.Dictionary
 import Rattletrap.Primitive.Int32
 import Rattletrap.Property
 import Rattletrap.PropertyValue
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Header.hs
+++ b/library/Rattletrap/Header.hs
@@ -5,7 +5,7 @@ import Rattletrap.Primitive.Int32
 import Rattletrap.Property
 import Rattletrap.PropertyValue
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Header.hs
+++ b/library/Rattletrap/Header.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Header where
 
-import Rattletrap.Dictionary
+import Rattletrap.Primitive.Dictionary
 import Rattletrap.Int32
 import Rattletrap.Property
 import Rattletrap.PropertyValue

--- a/library/Rattletrap/Header.hs
+++ b/library/Rattletrap/Header.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Header where
 
 import Rattletrap.Primitive.Dictionary
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.Property
 import Rattletrap.PropertyValue
 import Rattletrap.Text

--- a/library/Rattletrap/Initialization.hs
+++ b/library/Rattletrap/Initialization.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Initialization where
 
 import Rattletrap.Primitive.Int8Vector
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Initialization.hs
+++ b/library/Rattletrap/Initialization.hs
@@ -1,7 +1,6 @@
 module Rattletrap.Initialization where
 
-import Rattletrap.Primitive.Int8Vector
-import Rattletrap.Primitive.Vector
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Initialization.hs
+++ b/library/Rattletrap/Initialization.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Initialization where
 
-import Rattletrap.Int8Vector
+import Rattletrap.Primitive.Int8Vector
 import Rattletrap.Vector
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/Int8Vector.hs
+++ b/library/Rattletrap/Int8Vector.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Int8Vector where
 
-import Rattletrap.Int8
+import Rattletrap.Primitive.Int8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -8,7 +8,7 @@ import Rattletrap.AttributeMapping
 import Rattletrap.AttributeValue
 import Rattletrap.Cache
 import Rattletrap.ClassMapping
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Dictionary

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -18,7 +18,7 @@ import Rattletrap.Header
 import Rattletrap.Initialization
 import Rattletrap.Int32
 import Rattletrap.Primitive.Int8
-import Rattletrap.Int8Vector
+import Rattletrap.Primitive.Int8Vector
 import Rattletrap.KeyFrame
 import Rattletrap.List
 import Rattletrap.Mark

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -17,7 +17,7 @@ import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization
 import Rattletrap.Int32
-import Rattletrap.Int8
+import Rattletrap.Primitive.Int8
 import Rattletrap.Int8Vector
 import Rattletrap.KeyFrame
 import Rattletrap.List

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -11,7 +11,7 @@ import Rattletrap.ClassMapping
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
-import Rattletrap.Dictionary
+import Rattletrap.Primitive.Dictionary
 import Rattletrap.Float32
 import Rattletrap.Frame
 import Rattletrap.Header

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -31,7 +31,7 @@ import Rattletrap.Replication
 import Rattletrap.ReplicationValue
 import Rattletrap.Section
 import Rattletrap.Primitive.Text
-import Rattletrap.Vector
+import Rattletrap.Primitive.Vector
 import Rattletrap.Word32
 import Rattletrap.Word64
 import Rattletrap.Word8

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -34,7 +34,7 @@ import Rattletrap.Primitive.Text
 import Rattletrap.Primitive.Vector
 import Rattletrap.Word32
 import Rattletrap.Word64
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Control.Monad as Monad
 import qualified Data.Aeson.Casing as Casing

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -20,7 +20,7 @@ import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.Int8
 import Rattletrap.Primitive.Int8Vector
 import Rattletrap.KeyFrame
-import Rattletrap.List
+import Rattletrap.Primitive.List
 import Rattletrap.Mark
 import Rattletrap.Message
 import Rattletrap.Property

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -9,7 +9,7 @@ import Rattletrap.AttributeValue
 import Rattletrap.Cache
 import Rattletrap.ClassMapping
 import Rattletrap.Primitive.CompressedWord
-import Rattletrap.CompressedWordVector
+import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Dictionary
 import Rattletrap.Float32

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -16,7 +16,7 @@ import Rattletrap.Primitive.Float32
 import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.Int8
 import Rattletrap.Primitive.Int8Vector
 import Rattletrap.KeyFrame

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -12,7 +12,7 @@ import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
 import Rattletrap.Primitive.Dictionary
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -33,7 +33,7 @@ import Rattletrap.Section
 import Rattletrap.Primitive.Text
 import Rattletrap.Primitive.Vector
 import Rattletrap.Primitive.Word32
-import Rattletrap.Word64
+import Rattletrap.Primitive.Word64
 import Rattletrap.Primitive.Word8
 
 import qualified Control.Monad as Monad

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -32,7 +32,7 @@ import Rattletrap.ReplicationValue
 import Rattletrap.Section
 import Rattletrap.Primitive.Text
 import Rattletrap.Primitive.Vector
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 import Rattletrap.Word64
 import Rattletrap.Primitive.Word8
 

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -8,21 +8,14 @@ import Rattletrap.AttributeMapping
 import Rattletrap.AttributeValue
 import Rattletrap.Cache
 import Rattletrap.ClassMapping
-import Rattletrap.Primitive.CompressedWord
-import Rattletrap.Primitive.CompressedWordVector
 import Rattletrap.Content
-import Rattletrap.Primitive.Dictionary
-import Rattletrap.Primitive.Float32
 import Rattletrap.Frame
 import Rattletrap.Header
 import Rattletrap.Initialization
-import Rattletrap.Primitive.Int32
-import Rattletrap.Primitive.Int8
-import Rattletrap.Primitive.Int8Vector
 import Rattletrap.KeyFrame
-import Rattletrap.Primitive.List
 import Rattletrap.Mark
 import Rattletrap.Message
+import Rattletrap.Primitive
 import Rattletrap.Property
 import Rattletrap.PropertyValue
 import Rattletrap.RemoteId
@@ -30,11 +23,6 @@ import Rattletrap.Replay
 import Rattletrap.Replication
 import Rattletrap.ReplicationValue
 import Rattletrap.Section
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Vector
-import Rattletrap.Primitive.Word32
-import Rattletrap.Primitive.Word64
-import Rattletrap.Primitive.Word8
 
 import qualified Control.Monad as Monad
 import qualified Data.Aeson.Casing as Casing

--- a/library/Rattletrap/Json.hs
+++ b/library/Rattletrap/Json.hs
@@ -30,7 +30,7 @@ import Rattletrap.Replay
 import Rattletrap.Replication
 import Rattletrap.ReplicationValue
 import Rattletrap.Section
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Vector
 import Rattletrap.Word32
 import Rattletrap.Word64

--- a/library/Rattletrap/KeyFrame.hs
+++ b/library/Rattletrap/KeyFrame.hs
@@ -1,7 +1,6 @@
 module Rattletrap.KeyFrame where
 
-import Rattletrap.Primitive.Float32
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/KeyFrame.hs
+++ b/library/Rattletrap/KeyFrame.hs
@@ -1,6 +1,6 @@
 module Rattletrap.KeyFrame where
 
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 import Rattletrap.Word32
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/KeyFrame.hs
+++ b/library/Rattletrap/KeyFrame.hs
@@ -1,7 +1,7 @@
 module Rattletrap.KeyFrame where
 
 import Rattletrap.Primitive.Float32
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Mark.hs
+++ b/library/Rattletrap/Mark.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Mark where
 
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Mark.hs
+++ b/library/Rattletrap/Mark.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Mark where
 
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Mark.hs
+++ b/library/Rattletrap/Mark.hs
@@ -1,7 +1,6 @@
 module Rattletrap.Mark where
 
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Message.hs
+++ b/library/Rattletrap/Message.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Message where
 
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Message.hs
+++ b/library/Rattletrap/Message.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Message where
 
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Message.hs
+++ b/library/Rattletrap/Message.hs
@@ -1,7 +1,6 @@
 module Rattletrap.Message where
 
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Primitive.hs
+++ b/library/Rattletrap/Primitive.hs
@@ -1,0 +1,29 @@
+module Rattletrap.Primitive
+  ( module Rattletrap.Primitive.CompressedWord
+  , module Rattletrap.Primitive.CompressedWordVector
+  , module Rattletrap.Primitive.Dictionary
+  , module Rattletrap.Primitive.Float32
+  , module Rattletrap.Primitive.Int8
+  , module Rattletrap.Primitive.Int8Vector
+  , module Rattletrap.Primitive.Int32
+  , module Rattletrap.Primitive.List
+  , module Rattletrap.Primitive.Text
+  , module Rattletrap.Primitive.Vector
+  , module Rattletrap.Primitive.Word8
+  , module Rattletrap.Primitive.Word32
+  , module Rattletrap.Primitive.Word64
+  ) where
+
+import Rattletrap.Primitive.CompressedWord
+import Rattletrap.Primitive.CompressedWordVector
+import Rattletrap.Primitive.Dictionary
+import Rattletrap.Primitive.Float32
+import Rattletrap.Primitive.Int8
+import Rattletrap.Primitive.Int8Vector
+import Rattletrap.Primitive.Int32
+import Rattletrap.Primitive.List
+import Rattletrap.Primitive.Text
+import Rattletrap.Primitive.Vector
+import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive.Word64

--- a/library/Rattletrap/Primitive/CompressedWord.hs
+++ b/library/Rattletrap/Primitive/CompressedWord.hs
@@ -1,4 +1,4 @@
-module Rattletrap.CompressedWord where
+module Rattletrap.Primitive.CompressedWord where
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Primitive/CompressedWordVector.hs
+++ b/library/Rattletrap/Primitive/CompressedWordVector.hs
@@ -1,4 +1,4 @@
-module Rattletrap.CompressedWordVector where
+module Rattletrap.Primitive.CompressedWordVector where
 
 import Rattletrap.Primitive.CompressedWord
 

--- a/library/Rattletrap/Primitive/Dictionary.hs
+++ b/library/Rattletrap/Primitive/Dictionary.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Primitive.Dictionary where
 
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Primitive/Dictionary.hs
+++ b/library/Rattletrap/Primitive/Dictionary.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Dictionary where
+module Rattletrap.Primitive.Dictionary where
 
 import Rattletrap.Text
 

--- a/library/Rattletrap/Primitive/Float32.hs
+++ b/library/Rattletrap/Primitive/Float32.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Float32 where
+module Rattletrap.Primitive.Float32 where
 
 import Rattletrap.Utility
 

--- a/library/Rattletrap/Primitive/Int32.hs
+++ b/library/Rattletrap/Primitive/Int32.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Int32 where
+module Rattletrap.Primitive.Int32 where
 
 import Rattletrap.Utility
 

--- a/library/Rattletrap/Primitive/Int8.hs
+++ b/library/Rattletrap/Primitive/Int8.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Int8 where
+module Rattletrap.Primitive.Int8 where
 
 import Rattletrap.Utility
 

--- a/library/Rattletrap/Primitive/Int8Vector.hs
+++ b/library/Rattletrap/Primitive/Int8Vector.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Int8Vector where
+module Rattletrap.Primitive.Int8Vector where
 
 import Rattletrap.Primitive.Int8
 

--- a/library/Rattletrap/Primitive/List.hs
+++ b/library/Rattletrap/Primitive/List.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Primitive.List where
 
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Control.Monad as Monad
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Primitive/List.hs
+++ b/library/Rattletrap/Primitive/List.hs
@@ -1,4 +1,4 @@
-module Rattletrap.List where
+module Rattletrap.Primitive.List where
 
 import Rattletrap.Word32
 

--- a/library/Rattletrap/Primitive/Text.hs
+++ b/library/Rattletrap/Primitive/Text.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Text where
+module Rattletrap.Primitive.Text where
 
 import Rattletrap.Primitive.Int32
 import Rattletrap.Utility

--- a/library/Rattletrap/Primitive/Vector.hs
+++ b/library/Rattletrap/Primitive/Vector.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Vector where
+module Rattletrap.Primitive.Vector where
 
 import Rattletrap.Primitive.CompressedWord
 

--- a/library/Rattletrap/Primitive/Word32.hs
+++ b/library/Rattletrap/Primitive/Word32.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Word32 where
+module Rattletrap.Primitive.Word32 where
 
 import Rattletrap.Utility
 

--- a/library/Rattletrap/Primitive/Word64.hs
+++ b/library/Rattletrap/Primitive/Word64.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Word64 where
+module Rattletrap.Primitive.Word64 where
 
 import Rattletrap.Utility
 

--- a/library/Rattletrap/Primitive/Word8.hs
+++ b/library/Rattletrap/Primitive/Word8.hs
@@ -1,4 +1,4 @@
-module Rattletrap.Word8 where
+module Rattletrap.Primitive.Word8 where
 
 import Rattletrap.Utility
 

--- a/library/Rattletrap/Property.hs
+++ b/library/Rattletrap/Property.hs
@@ -1,8 +1,7 @@
 module Rattletrap.Property where
 
+import Rattletrap.Primitive
 import Rattletrap.PropertyValue
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word64
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Property.hs
+++ b/library/Rattletrap/Property.hs
@@ -2,7 +2,7 @@ module Rattletrap.Property where
 
 import Rattletrap.PropertyValue
 import Rattletrap.Primitive.Text
-import Rattletrap.Word64
+import Rattletrap.Primitive.Word64
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/Property.hs
+++ b/library/Rattletrap/Property.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Property where
 
 import Rattletrap.PropertyValue
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word64
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -6,7 +6,7 @@ import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.List
 import Rattletrap.Primitive.Text
 import Rattletrap.Word64
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -5,7 +5,7 @@ import Rattletrap.Primitive.Float32
 import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.List
 import Rattletrap.Primitive.Text
-import Rattletrap.Word64
+import Rattletrap.Primitive.Word64
 import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -1,7 +1,7 @@
 module Rattletrap.PropertyValue where
 
 import Rattletrap.Primitive.Dictionary
-import Rattletrap.Float32
+import Rattletrap.Primitive.Float32
 import Rattletrap.Int32
 import Rattletrap.List
 import Rattletrap.Text

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -2,7 +2,7 @@ module Rattletrap.PropertyValue where
 
 import Rattletrap.Primitive.Dictionary
 import Rattletrap.Primitive.Float32
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.List
 import Rattletrap.Text
 import Rattletrap.Word64

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -4,7 +4,7 @@ import Rattletrap.Primitive.Dictionary
 import Rattletrap.Primitive.Float32
 import Rattletrap.Primitive.Int32
 import Rattletrap.Primitive.List
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word64
 import Rattletrap.Word8
 

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -1,6 +1,6 @@
 module Rattletrap.PropertyValue where
 
-import Rattletrap.Dictionary
+import Rattletrap.Primitive.Dictionary
 import Rattletrap.Float32
 import Rattletrap.Int32
 import Rattletrap.List

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -1,12 +1,6 @@
 module Rattletrap.PropertyValue where
 
-import Rattletrap.Primitive.Dictionary
-import Rattletrap.Primitive.Float32
-import Rattletrap.Primitive.Int32
-import Rattletrap.Primitive.List
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word64
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary as Binary
 

--- a/library/Rattletrap/PropertyValue.hs
+++ b/library/Rattletrap/PropertyValue.hs
@@ -3,7 +3,7 @@ module Rattletrap.PropertyValue where
 import Rattletrap.Primitive.Dictionary
 import Rattletrap.Primitive.Float32
 import Rattletrap.Primitive.Int32
-import Rattletrap.List
+import Rattletrap.Primitive.List
 import Rattletrap.Text
 import Rattletrap.Word64
 import Rattletrap.Word8

--- a/library/Rattletrap/RemoteId.hs
+++ b/library/Rattletrap/RemoteId.hs
@@ -1,7 +1,6 @@
 module Rattletrap.RemoteId where
 
-import Rattletrap.Primitive.Word64
-import Rattletrap.Primitive.Word8
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/RemoteId.hs
+++ b/library/Rattletrap/RemoteId.hs
@@ -1,6 +1,6 @@
 module Rattletrap.RemoteId where
 
-import Rattletrap.Word64
+import Rattletrap.Primitive.Word64
 import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/RemoteId.hs
+++ b/library/Rattletrap/RemoteId.hs
@@ -1,7 +1,7 @@
 module Rattletrap.RemoteId where
 
 import Rattletrap.Word64
-import Rattletrap.Word8
+import Rattletrap.Primitive.Word8
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Replication.hs
+++ b/library/Rattletrap/Replication.hs
@@ -2,7 +2,7 @@ module Rattletrap.Replication where
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.ReplicationValue
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/Replication.hs
+++ b/library/Rattletrap/Replication.hs
@@ -2,7 +2,7 @@ module Rattletrap.Replication where
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Primitive.CompressedWord
+import Rattletrap.Primitive
 import Rattletrap.ReplicationValue
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/ReplicationValue.hs
+++ b/library/Rattletrap/ReplicationValue.hs
@@ -7,7 +7,7 @@ module Rattletrap.ReplicationValue
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.ReplicationValue.Destroyed
 import Rattletrap.ReplicationValue.Spawned
 import Rattletrap.ReplicationValue.Updated

--- a/library/Rattletrap/ReplicationValue.hs
+++ b/library/Rattletrap/ReplicationValue.hs
@@ -7,7 +7,7 @@ module Rattletrap.ReplicationValue
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Primitive.CompressedWord
+import Rattletrap.Primitive
 import Rattletrap.ReplicationValue.Destroyed
 import Rattletrap.ReplicationValue.Spawned
 import Rattletrap.ReplicationValue.Updated

--- a/library/Rattletrap/ReplicationValue/Spawned.hs
+++ b/library/Rattletrap/ReplicationValue/Spawned.hs
@@ -2,10 +2,8 @@ module Rattletrap.ReplicationValue.Spawned where
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Initialization
-import Rattletrap.Primitive.Text
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/ReplicationValue/Spawned.hs
+++ b/library/Rattletrap/ReplicationValue/Spawned.hs
@@ -5,7 +5,7 @@ import Rattletrap.ClassAttributeMap
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Initialization
 import Rattletrap.Primitive.Text
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/ReplicationValue/Spawned.hs
+++ b/library/Rattletrap/ReplicationValue/Spawned.hs
@@ -4,7 +4,7 @@ import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
 import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Initialization
-import Rattletrap.Text
+import Rattletrap.Primitive.Text
 import Rattletrap.Word32
 
 import qualified Data.Binary.Bits.Get as BinaryBit

--- a/library/Rattletrap/ReplicationValue/Spawned.hs
+++ b/library/Rattletrap/ReplicationValue/Spawned.hs
@@ -2,7 +2,7 @@ module Rattletrap.ReplicationValue.Spawned where
 
 import Rattletrap.ActorMap
 import Rattletrap.ClassAttributeMap
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 import Rattletrap.Initialization
 import Rattletrap.Text
 import Rattletrap.Word32

--- a/library/Rattletrap/ReplicationValue/Updated.hs
+++ b/library/Rattletrap/ReplicationValue/Updated.hs
@@ -3,7 +3,7 @@ module Rattletrap.ReplicationValue.Updated where
 import Rattletrap.ActorMap
 import Rattletrap.Attribute
 import Rattletrap.ClassAttributeMap
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/ReplicationValue/Updated.hs
+++ b/library/Rattletrap/ReplicationValue/Updated.hs
@@ -3,7 +3,7 @@ module Rattletrap.ReplicationValue.Updated where
 import Rattletrap.ActorMap
 import Rattletrap.Attribute
 import Rattletrap.ClassAttributeMap
-import Rattletrap.Primitive.CompressedWord
+import Rattletrap.Primitive
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit

--- a/library/Rattletrap/Section.hs
+++ b/library/Rattletrap/Section.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Section where
 
 import Rattletrap.Crc
-import Rattletrap.Word32
+import Rattletrap.Primitive.Word32
 
 import qualified Control.Monad as Monad
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Section.hs
+++ b/library/Rattletrap/Section.hs
@@ -1,7 +1,7 @@
 module Rattletrap.Section where
 
 import Rattletrap.Crc
-import Rattletrap.Primitive.Word32
+import Rattletrap.Primitive
 
 import qualified Control.Monad as Monad
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Text.hs
+++ b/library/Rattletrap/Text.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Text where
 
-import Rattletrap.Int32
+import Rattletrap.Primitive.Int32
 import Rattletrap.Utility
 
 import qualified Data.Binary as Binary

--- a/library/Rattletrap/Vector.hs
+++ b/library/Rattletrap/Vector.hs
@@ -1,6 +1,6 @@
 module Rattletrap.Vector where
 
-import Rattletrap.CompressedWord
+import Rattletrap.Primitive.CompressedWord
 
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified Data.Binary.Bits.Put as BinaryBit


### PR DESCRIPTION
This pull request makes a new module, `Rattletrap.Primitives`, and moves a bunch of other modules into it. Things in the new module are primitives like 32-bit integers or text. Generally you should be able to understand what they are based on the name alone. 

This change makes writing code in Rattletrap a lot nicer because you only need to import `Rattletrap.Primitives`. Also it reduces the number of files in `library/Rattletrap`, which is nice. 