### PR TITLE
Test against GHC 8.0.2-rc1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,20 @@
+compiler: ghc-8.0.1.20161117
+compiler-check: match-exact
 resolver: lts-7.10
+setup-info:
+  ghc:
+    linux64:
+      8.0.1.20161117:
+        content-length: 112047972
+        sha1: 6a6e4c9c53c71cc84b6966a9f61948542fd2f15a
+        url: https://downloads.haskell.org/~ghc/8.0.2-rc1/ghc-8.0.1.20161117-x86_64-deb8-linux.tar.xz
+    macosx:
+      8.0.1.20161117:
+        content-length: 113379688
+        sha1: 53ed03d986a49ea680c291540ce44ce469514d7c
+        url: https://downloads.haskell.org/~ghc/8.0.2-rc1/ghc-8.0.1.20161117-x86_64-apple-darwin.tar.xz
+    windows64:
+      8.0.1.20161117:
+        content-length: 155652048
+        sha1: 74118dd8fd8b5e4c69b25df1644273fbe13177c7
+        url: https://downloads.haskell.org/~ghc/8.0.2-rc1/ghc-8.0.1.20161117-x86_64-unknown-mingw32.tar.xz


### PR DESCRIPTION
https://mail.haskell.org/pipermail/glasgow-haskell-users/2016-November/026410.html

This should not be merged. I want to make sure of two things:

1. Rattletrap works with GHC 8.0.2. 
2. The `stack.yaml` works with Linux, macOS, and Windows. 