### PR TITLE
Upgrade to GHC 8.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-/.stack-work/
-/*.aux
-/*.cabal
-/*.exe
-/*.hp
-/*.prof
-/*.ps
-/*.tix
+.stack-work/
+*.aux
+*.cabal
+*.exe
+*.hp
+*.prof
+*.ps
+*.tix

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - stack --jobs 1 setup
   - stack build --jobs 1 --only-dependencies --test rattletrap
   - stack build --ghc-options -O2 --jobs 1 --pedantic --test --test-arguments '--match 29F5' rattletrap
-  - stack --jobs 1 sdist
+  - stack --jobs 1 sdist .
 after_success:
   - stack --jobs 1 build rattletrap-tools
   - stack exec upload-package

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ before_install:
   - sh tools/install-stack.sh
 script:
   - stack --jobs 1 setup
-  - stack build --jobs 1 --only-dependencies --test .
-  - stack build --ghc-options -O2 --jobs 1 --pedantic --test --test-arguments '--match 29F5' .
+  - stack build --jobs 1 --only-dependencies --test rattletrap
+  - stack build --ghc-options -O2 --jobs 1 --pedantic --test --test-arguments '--match 29F5' rattletrap
   - stack --jobs 1 sdist
 after_success:
-  - stack --jobs 1 build ./tools
+  - stack --jobs 1 build rattletrap-tools
   - stack exec upload-package
   - stack exec attach-binary

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,31 @@
+os:
+  - linux
+  - osx
+language: c
 addons:
   apt:
     packages:
-    - libgmp-dev
-  code_climate:
-    repo_token: f3ec70e01eb3f7fae0d1b61099d4ea64573c23e5a66bd34b9d6c2a1870ea5b63
-after_success:
-- stack --jobs 1 build aeson bytestring directory filepath github-release process temporary text zlib
-- stack --jobs 1 tools/upload-package.hs
-- stack --jobs 1 tools/attach-binary.hs
-before_install:
-- sh tools/install-stack.sh
+      - libgmp-dev
 cache:
   directories:
-  - $HOME/.local/bin
-  - $HOME/.stack
+    - $HOME/.local/bin
+    - $HOME/.stack
 env:
   global:
-  - HACKAGE_USERNAME=fozworth
-  # HACKAGE_PASSWORD
-  - secure: P2DddimkMUbzfSgu+ye6YMe6L4OTeijhGUYjejuzl0fKXm651lUwUAHQipFXo9+9nWKtCu68N1DxYBW6TI9Ez9AqKNXpVVVd5wmRvy/giMT1fLsay/U8Ie/8zLA3T13wxpILlqCs/UaLY4YJpAM2z37CkMEhFGqQxd3EKmeYNAM6rs778aIwncPCfsJwEmcXKqkOc3z4ACBoYIg+leRem5E1QfNB/zL5MRbhp0X3rh4ugO3OJ7X36smeO6eIIsPXNKikdIOp5Jfz+xWhLCTLTvoxho4VoFmt472Bi/B7F3lzywWBZXm6xvifQas31/v9UczflUui7uyMFj1OWV3/yI8SCoLsyf9EJq9+fymrrK1u0Z1ZMlNQRT10YPXF/z7BNHQon4U19Q/h6LiNNh1UN/iJj/N87vWjUJnDvZaxzlvBEeomWxnqmJlqDPmBDEb3Tj5TZXk512Pb/cKlNE7ySIceWm7unTobuk6/sUmZZFno7jLa89/m5Cml+mNeoCVAAg++/8Mv2pmoSjGpMdKMdTdmhRfFrr5bEi61PbSXKkesuyfPIdIyKrNryEFmHNZNKaGYn5RfooL8SlzwxHtXk/NkE4gv79Njkxo+TbWE882Yo47GCswfSGfeOFNKCZT59pTf0pRY/GkWK16Z+8bKg3hR5lfoXez/vhxL/JzU/sk=
-  # GITHUB_TOKEN
-  - secure: 'IaFWykf+LAWgXH1KOwnGfLDMxOmH697UmUZvi9xIR2ycac2Bga6hqdSUVQQ9keY5Pd5bjUZeSh3GJ8d+/hgWUTOp3qCReyf054GixyVQju4r9sYonBk5MqyeBRqrOo74UjVETlDc+tSSwBdYXBwz+Jk1I23JWEmq9n96Gf8v9gvv2dR7v6PVhdWhpep4qBLR96D5LCOFKyECymBTtqnYFJADxscTD+Hi+O+fwbbsd+DeTXIGZkvtNyDLQCArAfHXk7O5keHcVhTg2RYVz1i9isb/Lp4/nZCRG4CLTiFcoeIWwyWjs6uCWKnvGIN3ujZQo6y06rxsGuHRD10BwfZwh38TgYf8r939IyeRXXP9pmLiheG+Pd8NJuqwp0FGXYYw8ovAiQvECJIHZb64X2N8LmKQ9X2AAl3xgCTzkcEaYzV1AxC7RwfS9dsgxkt3ZVaNt6hJQPcvaSmtQhHEktQSPrttL6Ft2sbEKINvOJOmDP38aJ/pBBlyg/PL2x6cjC3XQ9MkQjBiKc5rQGEi5cQIw9tHF2U0Jelm5AfEMVYFeih6YI83mPuRIrvFsNQvFlISUi1i8FsbnC/B5TE1RQNFYavECPyibX6sUbfqhRikMMGhk7EE4/Fddb0B3qHi0jh9LYRoMBJ3+Nq5NfILjp2WoruVQBZDM4aoVjCgRrpgQ/Y='
-language: c
-os:
-- linux
-- osx
+    - HACKAGE_USERNAME=fozworth
+    # HACKAGE_PASSWORD
+    - secure: P2DddimkMUbzfSgu+ye6YMe6L4OTeijhGUYjejuzl0fKXm651lUwUAHQipFXo9+9nWKtCu68N1DxYBW6TI9Ez9AqKNXpVVVd5wmRvy/giMT1fLsay/U8Ie/8zLA3T13wxpILlqCs/UaLY4YJpAM2z37CkMEhFGqQxd3EKmeYNAM6rs778aIwncPCfsJwEmcXKqkOc3z4ACBoYIg+leRem5E1QfNB/zL5MRbhp0X3rh4ugO3OJ7X36smeO6eIIsPXNKikdIOp5Jfz+xWhLCTLTvoxho4VoFmt472Bi/B7F3lzywWBZXm6xvifQas31/v9UczflUui7uyMFj1OWV3/yI8SCoLsyf9EJq9+fymrrK1u0Z1ZMlNQRT10YPXF/z7BNHQon4U19Q/h6LiNNh1UN/iJj/N87vWjUJnDvZaxzlvBEeomWxnqmJlqDPmBDEb3Tj5TZXk512Pb/cKlNE7ySIceWm7unTobuk6/sUmZZFno7jLa89/m5Cml+mNeoCVAAg++/8Mv2pmoSjGpMdKMdTdmhRfFrr5bEi61PbSXKkesuyfPIdIyKrNryEFmHNZNKaGYn5RfooL8SlzwxHtXk/NkE4gv79Njkxo+TbWE882Yo47GCswfSGfeOFNKCZT59pTf0pRY/GkWK16Z+8bKg3hR5lfoXez/vhxL/JzU/sk=
+    # GITHUB_TOKEN
+    - secure: 'IaFWykf+LAWgXH1KOwnGfLDMxOmH697UmUZvi9xIR2ycac2Bga6hqdSUVQQ9keY5Pd5bjUZeSh3GJ8d+/hgWUTOp3qCReyf054GixyVQju4r9sYonBk5MqyeBRqrOo74UjVETlDc+tSSwBdYXBwz+Jk1I23JWEmq9n96Gf8v9gvv2dR7v6PVhdWhpep4qBLR96D5LCOFKyECymBTtqnYFJADxscTD+Hi+O+fwbbsd+DeTXIGZkvtNyDLQCArAfHXk7O5keHcVhTg2RYVz1i9isb/Lp4/nZCRG4CLTiFcoeIWwyWjs6uCWKnvGIN3ujZQo6y06rxsGuHRD10BwfZwh38TgYf8r939IyeRXXP9pmLiheG+Pd8NJuqwp0FGXYYw8ovAiQvECJIHZb64X2N8LmKQ9X2AAl3xgCTzkcEaYzV1AxC7RwfS9dsgxkt3ZVaNt6hJQPcvaSmtQhHEktQSPrttL6Ft2sbEKINvOJOmDP38aJ/pBBlyg/PL2x6cjC3XQ9MkQjBiKc5rQGEi5cQIw9tHF2U0Jelm5AfEMVYFeih6YI83mPuRIrvFsNQvFlISUi1i8FsbnC/B5TE1RQNFYavECPyibX6sUbfqhRikMMGhk7EE4/Fddb0B3qHi0jh9LYRoMBJ3+Nq5NfILjp2WoruVQBZDM4aoVjCgRrpgQ/Y='
+
+before_install:
+  - sh tools/install-stack.sh
 script:
-- stack --jobs 1 setup
-- stack build --ghc-options -O2 --jobs 1 --only-dependencies --test
-- stack build --ghc-options -O2 --jobs 1 --pedantic --test --test-arguments '--match 29F5'
-- stack --jobs 1 sdist
+  - stack --jobs 1 setup
+  - stack build --jobs 1 --only-dependencies --test .
+  - stack build --ghc-options -O2 --jobs 1 --pedantic --test --test-arguments '--match 29F5' .
+  - stack --jobs 1 sdist
+after_success:
+  - stack --jobs 1 build ./tools
+  - stack exec upload-package
+  - stack exec attach-binary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,4 +17,4 @@ test_script:
   - stack --jobs 1 sdist .
 on_success:
   - stack --jobs 1 build rattletrap-tools
-  - stack attach-binary
+  - stack exec attach-binary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ test_script:
   - stack --jobs 1 setup > nul
   - stack build --jobs 1 --only-dependencies --test rattletrap
   - stack build --ghc-options -O2 --jobs 1 --pedantic --test rattletrap
-  - stack --jobs 1 sdist
+  - stack --jobs 1 sdist .
 on_success:
   - stack --jobs 1 build rattletrap-tools
   - stack attach-binary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ install:
   - powershell -File tools/install-stack.ps1
 test_script:
   - stack --jobs 1 setup > nul
-  - stack build --jobs 1 --only-dependencies --test .
-  - stack build --ghc-options -O2 --jobs 1 --pedantic --test .
+  - stack build --jobs 1 --only-dependencies --test rattletrap
+  - stack build --ghc-options -O2 --jobs 1 --pedantic --test rattletrap
   - stack --jobs 1 sdist
 on_success:
-  - stack --jobs 1 build ./tools
+  - stack --jobs 1 build rattletrap-tools
   - stack attach-binary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,20 @@
 build: off
+platform: x64
+version: '{build}'
 clone_folder: c:/rattletrap
 environment:
   GITHUB_TOKEN:
     secure: 'L/78Qw3wSosowhhilcm/u+wHOM97yiHdXgz8pbwRD3PQVtVSB1lZQ/BDaIm8RpsA'
   PATH: c:/bin;%PATH%
   STACK_ROOT: c:/stack
+
 install:
-- powershell -File tools/install-stack.ps1
-on_success:
-- stack --jobs 1 build bytestring github-release process temporary zlib
-- stack --jobs 1 tools/attach-binary.hs
-platform: x64
+  - powershell -File tools/install-stack.ps1
 test_script:
-- stack --jobs 1 setup > nul
-- stack build --ghc-options -O2 --jobs 1 --only-dependencies --test
-- stack build --ghc-options -O2 --jobs 1 --pedantic --test
-- stack --jobs 1 sdist
-version: '{build}'
+  - stack --jobs 1 setup > nul
+  - stack build --jobs 1 --only-dependencies --test .
+  - stack build --ghc-options -O2 --jobs 1 --pedantic --test .
+  - stack --jobs 1 sdist
+on_success:
+  - stack --jobs 1 build ./tools
+  - stack attach-binary

--- a/package.yaml
+++ b/package.yaml
@@ -1,59 +1,61 @@
+name: rattletrap
+version: 2.5.0
+
 category: Game
 description: Rattletrap parses and generates Rocket League replays.
+extra-source-files:
+  - CHANGELOG.markdown
+  - replays/*.replay
+  - package.yaml
+  - README.markdown
+  - stack.yaml
+github: tfausak/rattletrap
+license-file: LICENSE.markdown
+license: MIT
+maintainer: Taylor Fausak
+synopsis: Parse and generate Rocket League replays.
+
+dependencies:
+  - aeson >= 1.2.1 && < 1.3
+  - base >= 4.10.0 && < 4.11
+  - bimap >= 0.3.3 && < 0.4
+  - binary >= 0.8.5 && < 0.9
+  - binary-bits >= 0.5 && < 0.6
+  - bytestring >= 0.10.8 && < 0.11
+  - containers >= 0.5.10 && < 0.6
+  - data-binary-ieee754 >= 0.4.4 && < 0.5
+  - template-haskell >= 2.12.0 && < 2.13
+  - text >= 1.2.2 && < 1.3
+  - vector >= 0.12.0 && < 0.13
+ghc-options: -Wall
+
+library:
+  default-extensions:
+    - Strict
+  other-modules: Paths_rattletrap
+  source-dirs: library
+
 executables:
   rattletrap:
     dependencies:
-    - base
-    - rattletrap
+      - rattletrap
     ghc-options:
-    - -rtsopts
-    - -threaded
-    - -with-rtsopts=-N
+      - -rtsopts
+      - -threaded
+      - -with-rtsopts=-N
     main: Main.hs
     source-dirs: executables
-extra-source-files:
-- CHANGELOG.markdown
-- replays/*.replay
-- package.yaml
-- README.markdown
-- stack.yaml
-ghc-options: -Wall
-github: tfausak/rattletrap
-library:
-  default-extensions:
-  - Strict
-  dependencies:
-  - aeson >=0.11 && <1.3
-  - base >=4.9 && <4.11
-  - bimap >=0.3 && <0.4
-  - binary >=0.8 && <0.9
-  - binary-bits >=0.5 && <0.6
-  - bytestring >=0.10 && <0.11
-  - containers >=0.5 && <0.6
-  - data-binary-ieee754 >=0.4 && <0.5
-  - template-haskell >=2.11 && <2.13
-  - text >=1.2 && <1.3
-  - vector >=0.11 && <0.13
-  other-modules: Paths_rattletrap
-  source-dirs: library
-license: MIT
-license-file: LICENSE.markdown
-maintainer: Taylor Fausak
-name: rattletrap
-synopsis: Parse and generate Rocket League replays.
+
 tests:
   test:
     dependencies:
-    - base
-    - bytestring
-    - filepath >=1.4 && <1.5
-    - hspec >=2.4 && <2.5
-    - rattletrap
-    - temporary >=1.2 && <1.3
+      - filepath >= 1.4.1 && < 1.5
+      - hspec >= 2.4.4 && < 2.5
+      - rattletrap
+      - temporary >= 1.2.1 && < 1.3
     ghc-options:
-    - -rtsopts
-    - -threaded
-    - -with-rtsopts=-N
+      - -rtsopts
+      - -threaded
+      - -with-rtsopts=-N
     main: Main.hs
     source-dirs: tests
-version: '2.5.0'

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ maintainer: Taylor Fausak
 synopsis: Parse and generate Rocket League replays.
 
 dependencies:
-  - aeson >= 1.2.1 && < 1.3
+  - aeson >= 1.1.2 && < 1.3
   - base >= 4.10.0 && < 4.11
   - bimap >= 0.3.3 && < 0.4
   - binary >= 0.8.5 && < 0.9

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,43 @@
-resolver: lts-8.0
+resolver: ghc-8.2.1
+
+extra-deps:
+  - aeson-1.2.1.0
+  - ansi-terminal-0.6.3.1
+  - async-2.1.1.1
+  - attoparsec-0.13.1.0
+  - base-compat-0.9.3
+  - bimap-0.3.3
+  - binary-bits-0.5
+  - call-stack-0.1.0
+  - data-binary-ieee754-0.4.4
+  - dlist-0.8.0.3
+  - exceptions-0.8.3
+  - hashable-1.2.6.1
+  - hspec-2.4.4
+  - hspec-core-2.4.4
+  - hspec-discover-2.4.4
+  - hspec-expectations-0.8.2
+  - HUnit-1.6.0.0
+  - integer-logarithms-1.0.2
+  - mtl-2.2.1
+  - old-locale-1.0.0.7
+  - primitive-0.6.2.0
+  - QuickCheck-2.10.0.1
+  - quickcheck-io-0.2.0
+  - random-1.1
+  - scientific-0.3.5.1
+  - setenv-0.1.1.3
+  - stm-2.4.4.1
+  - tagged-0.8.5
+  - temporary-1.2.1
+  - text-1.2.2.2
+  - tf-random-0.5
+  - time-locale-compat-0.1.1.3
+  - transformers-compat-0.5.1.4
+  - unordered-containers-0.2.8.0
+  - uuid-types-1.0.3
+  - vector-0.12.0.1
+
+flags:
+  time-locale-compat:
+    old-locale: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
 resolver: ghc-8.2.1
 
+packages:
+  - .
+  - tools
+
 extra-deps:
   - aeson-1.2.1.0
   - ansi-terminal-0.6.3.1
@@ -38,6 +42,79 @@ extra-deps:
   - uuid-types-1.0.3
   - vector-0.12.0.1
 
+  # tools
+  - adjunctions-4.3
+  - ansi-wl-pprint-0.6.7.3
+  - asn1-encoding-0.9.5
+  - asn1-parse-0.9.4
+  - asn1-types-0.3.2
+  - base-orphans-0.6
+  - base64-bytestring-1.0.0.1
+  - bifunctors-5.4.2
+  - blaze-builder-0.4.0.2
+  - blaze-html-0.9.0.1
+  - blaze-markup-0.8.0.0
+  - byteable-0.1.1
+  - cabal-doctest-1.0.2
+  - case-insensitive-1.2.0.10
+  - cereal-0.5.4.0
+  - charset-0.3.7.1
+  - comonad-5.0.1
+  - connection-0.2.8
+  - contravariant-1.4
+  - cookie-0.4.2.1
+  - cryptonite-0.24
+  - data-default-class-0.1.2.0
+  - distributive-0.5.2
+  - fail-4.9.0.0
+  - fingertree-0.1.1.0
+  - foundation-0.0.13
+  - free-4.12.4
+  - github-release-1.0.3
+  - hourglass-0.2.10
+  - HTTP-4000.3.7
+  - http-client-0.5.7.0
+  - http-client-tls-0.3.5.1
+  - http-types-0.9.1
+  - kan-extensions-5.0.2
+  - lens-4.15.3
+  - memory-0.14.6
+  - mime-types-0.1.0.7
+  - network-2.6.3.2
+  - network-uri-2.6.1.0
+  - Only-0.1
+  - optparse-applicative-0.14.0.0
+  - optparse-generic-1.2.2
+  - parallel-3.2.1.1
+  - parsec-3.1.11
+  - parsers-0.12.5
+  - pem-0.2.2
+  - prelude-extras-0.4.0.3
+  - profunctors-5.2
+  - reducers-3.12.1
+  - reflection-2.1.2
+  - safe-0.3.15
+  - semigroupoids-5.2
+  - semigroups-0.18.3
+  - socks-0.5.5
+  - StateVar-1.1.0.4
+  - streaming-commons-0.1.18
+  - system-filepath-0.4.13.4
+  - th-abstraction-0.2.3.0
+  - tls-1.3.11
+  - trifecta-1.7
+  - uri-templater-0.2.1.0
+  - utf8-string-1.0.1.1
+  - void-0.7.2
+  - x509-1.7.1
+  - x509-store-1.6.3
+  - x509-system-1.6.5
+  - x509-validation-1.6.8
+  - zlib-0.6.1.2
+
 flags:
   time-locale-compat:
     old-locale: false
+
+# TODO: Use a version of github-release that supports base-4.10.0.0.
+allow-newer: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -70,7 +70,7 @@ extra-deps:
   - fingertree-0.1.1.0
   - foundation-0.0.13
   - free-4.12.4
-  - github-release-1.0.3
+  - github-release-1.0.4
   - hourglass-0.2.10
   - HTTP-4000.3.7
   - http-client-0.5.7.0
@@ -115,6 +115,3 @@ extra-deps:
 flags:
   time-locale-compat:
     old-locale: false
-
-# TODO: Use a version of github-release that supports base-4.10.0.0.
-allow-newer: true

--- a/tools/attach-binary.hs
+++ b/tools/attach-binary.hs
@@ -1,10 +1,3 @@
-{- stack --resolver lts-8.0 script
-  --package bytestring
-  --package github-release
-  --package process
-  --package temporary
-  --package zlib
--}
 import qualified Codec.Compression.GZip as GZip
 import qualified Data.ByteString.Lazy as ByteString
 import qualified GitHubRelease

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -1,0 +1,23 @@
+name: rattletrap-tools
+version: 1.0.0
+
+dependencies:
+  - base
+  - bytestring
+  - process
+ghc-options: -Wall
+
+executables:
+  attach-binary:
+    dependencies:
+      - github-release
+      - temporary
+      - zlib
+    main: attach-binary.hs
+  upload-package:
+    dependencies:
+      - aeson
+      - directory
+      - filepath
+      - text
+    main: upload-package.hs

--- a/tools/upload-package.hs
+++ b/tools/upload-package.hs
@@ -1,7 +1,6 @@
 import qualified Control.Monad as Monad
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as ByteString
-import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import qualified System.Directory as Directory
 import qualified System.Environment as Environment

--- a/tools/upload-package.hs
+++ b/tools/upload-package.hs
@@ -1,11 +1,3 @@
-{- stack --resolver lts-8.0 script
-  --package aeson
-  --package bytestring
-  --package directory
-  --package filepath
-  --package process
-  --package text
--}
 import qualified Control.Monad as Monad
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as ByteString


### PR DESCRIPTION
GHC 8.2.1 was released yesterday: https://www.haskell.org/ghc/download_ghc_8_2_1.html

This pull request upgrades from `lts-8.0`, which uses GHC 8.0.2, to `ghc-8.2.1`. It also does a couple other things:

- Explicitly list all dependencies in the `stack.yaml`. This way I don't have to wait on the LTS resolver to update.
- Cleans up the `package.yaml` to be more human friendly. 
- Tightens up a lot of dependency version bounds. I'm not interested in maintaining compatibility with old versions, and I'm definitely not going to test them. To avoid random build failures like https://github.com/tfausak/autoexporter/issues/7 I'm just going to tighten the bounds. 
  - It's worth noting that upgrading dependencies is not a major-level (or event a patch-level) change for SemVer: http://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api