### PR TITLE
Upgrade to Stackage nightly 2018-06-01

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.0
+resolver: nightly-2018-06-01


### PR DESCRIPTION
Sadly the build fails:

```
336    C:\Users\appveyor\AppData\Local\Temp\1\stack2172\network-2.6.3.5\Network\Socket\Types.hsc:764:16: error:
337        parse error on input `CALLCONV'
338        |
339    764 | foreign import CALLCONV unsafe "ntohs" ntohs :: Word16 -> Word16
340        |     
```

Related issues:

- https://github.com/haskell/network/issues/313
- https://github.com/commercialhaskell/stack/issues/3944