### PR TITLE
Optionally enable static linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,8 @@ before_install:
 script:
   - stack setup
   - stack build --only-dependencies --test
-  - stack build --flag rattletrap:static --no-run-tests --test
-  - ls -h -l $( stack exec which rattletrap )
-  - ldd $( stack exec which rattletrap ) || otool -L $( stack exec which rattletrap )
-  - stack build --flag rattletrap:static --test
+  - stack build --no-run-tests --test
+  - stack build --test
   - stack sdist
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,9 @@ script:
   - stack setup
   - stack build --only-dependencies --test
   - stack build --flag rattletrap:static --no-run-tests --test
-  - ls -h -l $( stack exec which rattletrap ) && ldd $( stack exec which rattletrap ) || otool -L $( stack exec which rattletrap )
-  - stack build --test
+  - ls -h -l $( stack exec which rattletrap )
+  - ldd $( stack exec which rattletrap ) || otool -L $( stack exec which rattletrap )
+  - stack build --flag rattletrap:static --test
   - stack sdist
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ script:
   - stack setup
   - stack build --only-dependencies --test
   - stack build --no-run-tests --test
+  - ls -h -l $( stack exec which rattletrap )
+  - ldd $( stack exec which rattletrap )
+  - stack build --force-dirty --ghc-options='-optl-static -optl-pthread' --no-run-tests --test
+  - ls -h -l $( stack exec which rattletrap )
+  - ldd $( stack exec which rattletrap )
   - stack build --test
   - stack sdist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - stack build --no-run-tests --test
   - ls -h -l $( stack exec which rattletrap )
   - ldd $( stack exec which rattletrap )
-  - stack build --force-dirty --ghc-options='-optl-static -optl-pthread' --no-run-tests --test
+  - stack build --force-dirty --ghc-options='-optl-static -optl-pthread -fPIC' --no-run-tests --test
   - ls -h -l $( stack exec which rattletrap )
   - ldd $( stack exec which rattletrap )
   - stack build --test

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,8 @@ before_install:
 script:
   - stack setup
   - stack build --only-dependencies --test
-  - stack build --no-run-tests --test
-  - ls -h -l $( stack exec which rattletrap )
-  - ldd $( stack exec which rattletrap )
-  - stack build --force-dirty --ghc-options='-optl-static -optl-pthread -fPIC' --no-run-tests --test
-  - ls -h -l $( stack exec which rattletrap )
-  - ldd $( stack exec which rattletrap )
+  - stack build --flag rattletrap:static --no-run-tests --test
+  - ls -h -l $( stack exec which rattletrap ) && ldd $( stack exec which rattletrap ) || otool -L $( stack exec which rattletrap )
   - stack build --test
   - stack sdist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.8 AS build
+RUN apk add --no-cache cabal ghc gmp-dev musl-dev wget zlib-dev
+RUN cabal update
+RUN cabal new-install hpack
+WORKDIR /root/rattletrap
+COPY . .
+RUN ~/.cabal/bin/hpack --force
+RUN cabal new-build --flags static
+RUN cp $( cabal new-exec which rattletrap | tail -n 1 ) /usr/local/bin/
+
+FROM alpine:3.8
+COPY --from=build /usr/local/bin/rattletrap /usr/local/bin/rattletrap
+CMD rattletrap

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,11 @@ ghc-options:
   - -Wno-safe
   - -Wno-unsafe
 
+flags:
+  static:
+    default: false
+    manual: true
+
 library:
   source-dirs: library
 
@@ -46,6 +51,9 @@ executable:
     - -threaded
   main: Main.hs
   source-dirs: executables
+  when:
+    - condition: flag(static)
+      ld-options: -static
 
 tests:
   test:


### PR DESCRIPTION
This fixes #66. It adds a `static` flag to enable static linking. It also adds a `Dockerfile` that builds a static executable in a Docker container using Alpine linux. Unfortunately the static binary isn't available as a build artifact, but it can be pushed to Docker Hub. 