### PR TITLE
Add "--fast" option for header-only mode

### DIFF
--- a/library/Rattletrap/Console/Main.hs
+++ b/library/Rattletrap/Console/Main.hs
@@ -47,7 +47,7 @@ getEncoder config = case getMode config of
   ModeDecode -> if configCompact config
     then LazyBytes.toStrict . Json.encode
     else Rattletrap.encodeReplayJson
-  ModeEncode -> Rattletrap.encodeReplayFile
+  ModeEncode -> Rattletrap.encodeReplayFile $ configFast config
 
 getInput :: Config -> IO Bytes.ByteString
 getInput config = case configInput config of

--- a/library/Rattletrap/Console/Main.hs
+++ b/library/Rattletrap/Console/Main.hs
@@ -82,6 +82,7 @@ type Update = Config -> Either String Config
 options :: [Option]
 options =
   [ compactOption
+  , fastOption
   , helpOption
   , inputOption
   , modeOption
@@ -95,6 +96,13 @@ compactOption = Console.Option
   ["compact"]
   (Console.NoArg (\config -> pure config { configCompact = True }))
   "minify JSON output"
+
+fastOption :: Option
+fastOption = Console.Option
+  ['f']
+  ["fast"]
+  (Console.NoArg (\config -> pure config { configFast = True }))
+  "only encode or decode the header"
 
 helpOption :: Option
 helpOption = Console.Option
@@ -148,6 +156,7 @@ applyUpdate config update = update config
 
 data Config = Config
   { configCompact :: Bool
+  , configFast :: Bool
   , configHelp :: Bool
   , configInput :: Maybe String
   , configMode :: Maybe Mode
@@ -158,6 +167,7 @@ data Config = Config
 defaultConfig :: Config
 defaultConfig = Config
   { configCompact = False
+  , configFast = False
   , configHelp = False
   , configInput = Nothing
   , configMode = Nothing

--- a/library/Rattletrap/Console/Main.hs
+++ b/library/Rattletrap/Console/Main.hs
@@ -39,7 +39,7 @@ rattletrap name arguments = do
 
 getDecoder :: Config -> Bytes.ByteString -> Either String Rattletrap.Replay
 getDecoder config = case getMode config of
-  ModeDecode -> Rattletrap.decodeReplayFile
+  ModeDecode -> Rattletrap.decodeReplayFile $ configFast config
   ModeEncode -> Rattletrap.decodeReplayJson
 
 getEncoder :: Config -> Rattletrap.Replay -> Bytes.ByteString

--- a/library/Rattletrap/Decode/Replay.hs
+++ b/library/Rattletrap/Decode/Replay.hs
@@ -7,6 +7,8 @@ import Rattletrap.Decode.Common
 import Rattletrap.Decode.Content
 import Rattletrap.Decode.Header
 import Rattletrap.Decode.Section
+import Rattletrap.Encode.Content
+import Rattletrap.Type.Content
 import Rattletrap.Type.Dictionary
 import Rattletrap.Type.Header
 import Rattletrap.Type.Int32le
@@ -17,15 +19,19 @@ import Rattletrap.Type.Section
 import Rattletrap.Type.Str
 import Rattletrap.Type.Word32le
 
-decodeReplay :: Decode Replay
-decodeReplay = do
+decodeReplay :: Bool -> Decode Replay
+decodeReplay fast = do
   header <- decodeSection decodeHeader
-  Replay header <$> decodeSection
-    (decodeContent
-      (getVersion (sectionBody header))
-      (getNumFrames (sectionBody header))
-      (getMaxChannels (sectionBody header))
-    )
+  content <- if fast
+    then pure $ toSection putContent defaultContent
+    else
+      let body = sectionBody header
+      in
+        decodeSection $ decodeContent
+          (getVersion body)
+          (getNumFrames body)
+          (getMaxChannels body)
+  pure $ Replay header content
 
 getVersion :: Header -> (Int, Int, Int)
 getVersion header =

--- a/library/Rattletrap/Type/Content.hs
+++ b/library/Rattletrap/Type/Content.hs
@@ -2,6 +2,7 @@
 
 module Rattletrap.Type.Content
   ( Content(..)
+  , defaultContent
   )
 where
 
@@ -52,3 +53,19 @@ data Content = Content
   } deriving (Eq, Ord, Show)
 
 $(deriveJson ''Content)
+
+defaultContent :: Content
+defaultContent = Content
+  { contentLevels = List []
+  , contentKeyFrames = List []
+  , contentStreamSize = Word32le 0
+  , contentFrames = []
+  , contentMessages = List []
+  , contentMarks = List []
+  , contentPackages = List []
+  , contentObjects = List []
+  , contentNames = List []
+  , contentClassMappings = List []
+  , contentCaches = List []
+  , contentUnknown = Nothing
+  }

--- a/library/Rattletrap/Utility/Helper.hs
+++ b/library/Rattletrap/Utility/Helper.hs
@@ -9,9 +9,12 @@ module Rattletrap.Utility.Helper
 where
 
 import Rattletrap.Decode.Common
+import Rattletrap.Encode.Content
 import Rattletrap.Decode.Replay
 import Rattletrap.Encode.Replay
 import Rattletrap.Type.Replay
+import Rattletrap.Type.Section
+import Rattletrap.Type.Content
 
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Encode.Pretty as Json
@@ -36,6 +39,8 @@ decodeReplayJson :: Bytes.ByteString -> Either String Replay
 decodeReplayJson = Json.eitherDecodeStrict'
 
 -- | Encodes a raw replay.
-encodeReplayFile :: Replay -> Bytes.ByteString
-encodeReplayFile replay =
-  LazyBytes.toStrict (Binary.runPut (putReplay replay))
+encodeReplayFile :: Bool -> Replay -> Bytes.ByteString
+encodeReplayFile fast replay =
+  LazyBytes.toStrict . Binary.runPut . putReplay $ if fast
+    then replay { replayContent = toSection putContent defaultContent }
+    else replay

--- a/library/Rattletrap/Utility/Helper.hs
+++ b/library/Rattletrap/Utility/Helper.hs
@@ -20,8 +20,8 @@ import qualified Data.ByteString as Bytes
 import qualified Data.ByteString.Lazy as LazyBytes
 
 -- | Parses a raw replay.
-decodeReplayFile :: Bytes.ByteString -> Either String Replay
-decodeReplayFile = runDecode decodeReplay
+decodeReplayFile :: Bool -> Bytes.ByteString -> Either String Replay
+decodeReplayFile fast = runDecode $ decodeReplay fast
 
 -- | Encodes a replay as JSON.
 encodeReplayJson :: Replay -> Bytes.ByteString


### PR DESCRIPTION
This is an alternative to #101. Thanks to @IvanMalison for showing me that this wasn't as hard as I thought! 

This adds a `--fast` (`-f`) option to put Rattletrap into "header-only mode". Ignoring the content speeds things up dramatically. Since the header contains lots of interesting metadata, many users of Rattletrap are interested in parsing that information quickly. 

``` sh
# this is the largest replay in the test suite
$ ls -lh replays/7256.replay
-rw-r--r-- 1 taylor taylor 1.6M May 18 08:37 replays/7256.replay

# parsing the whole thing takes 12 seconds on my machine
$ stack exec -- time rattletrap -i replays/7256.replay -o /dev/null
12.03user 0.34system 0:12.36elapsed 100%CPU (0avgtext+0avgdata 1091164maxresident)k
0inputs+0outputs (0major+270767minor)pagefaults 0swaps

# generating compact JSON speeds it up to 2 seconds
$ stack exec -- time rattletrap -c -i replays/7256.replay -o /dev/null
1.96user 0.05system 0:02.02elapsed 99%CPU (0avgtext+0avgdata 264760maxresident)k
0inputs+0outputs (0major+64149minor)pagefaults 0swaps

# ignoring the content gets it down to 0.01 seconds
$ stack exec -- time rattletrap -f -i replays/7256.replay -o /dev/null
0.00user 0.00system 0:00.01elapsed 45%CPU (0avgtext+0avgdata 12368maxresident)k
0inputs+0outputs (0major+1094minor)pagefaults 0swaps
```

Encoding replays is also faster, but that's not a common use case. 