### PR TITLE
Encode large numbers as strings in JSON

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ version: '{build}'
 clone_folder: c:/rattletrap
 
 environment:
+  APPVEYOR_CACHE_SKIP_RESTORE: 'true'
   GITHUB_TOKEN:
     secure: 'L/78Qw3wSosowhhilcm/u+wHOM97yiHdXgz8pbwRD3PQVtVSB1lZQ/BDaIm8RpsA'
   PATH: c:/bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ version: '{build}'
 clone_folder: c:/rattletrap
 
 environment:
-  APPVEYOR_CACHE_SKIP_RESTORE: 'true'
   GITHUB_TOKEN:
     secure: 'L/78Qw3wSosowhhilcm/u+wHOM97yiHdXgz8pbwRD3PQVtVSB1lZQ/BDaIm8RpsA'
   PATH: c:/bin;%PATH%

--- a/library/Rattletrap/Type/CompressedWord.hs
+++ b/library/Rattletrap/Type/CompressedWord.hs
@@ -7,6 +7,8 @@ where
 
 import Rattletrap.Type.Common
 
+-- | Although there's no guarantee that these values will not overflow, it's
+-- exceptionally unlikely. Most 'CompressedWord's are very small.
 data CompressedWord = CompressedWord
   { compressedWordLimit :: Word
   , compressedWordValue :: Word

--- a/library/Rattletrap/Type/GameModeAttribute.hs
+++ b/library/Rattletrap/Type/GameModeAttribute.hs
@@ -9,6 +9,10 @@ import Rattletrap.Type.Common
 
 data GameModeAttribute = GameModeAttribute
   { gameModeAttributeNumBits :: Int
+  -- ^ This field is guaranteed to be small. In other words, it won't overflow.
+  -- It's stored as a regular 'Int' rather than something more precise like an
+  -- 'Int8' because it just gets passed to functions that expect 'Int's.
+  -- There's no reason to do a bunch of conversions.
   , gameModeAttributeWord :: Word8
   } deriving (Eq, Ord, Show)
 

--- a/library/Rattletrap/Type/Int64le.hs
+++ b/library/Rattletrap/Type/Int64le.hs
@@ -1,14 +1,28 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Int64le
   ( Int64le(..)
   )
 where
 
-import Rattletrap.Type.Common
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.Int as Int
+import qualified Data.Scientific as Scientific
+import qualified Data.Text as Text
+import qualified Text.Read as Read
 
 newtype Int64le = Int64le
-  { int64leValue :: Int64
+  { int64leValue :: Int.Int64
   } deriving (Eq, Ord, Show)
 
-$(deriveJson ''Int64le)
+instance Aeson.FromJSON Int64le where
+  parseJSON value = case value of
+    Aeson.String text -> case Read.readEither $ Text.unpack text of
+      Left _ -> Aeson.typeMismatch "Int64le" value
+      Right int64 -> pure $ Int64le int64
+    Aeson.Number number -> case Scientific.toBoundedInteger number of
+      Nothing -> Aeson.typeMismatch "Int64le" value
+      Just int64 -> pure $ Int64le int64
+    _ -> Aeson.typeMismatch "Int64le" value
+
+instance Aeson.ToJSON Int64le where
+  toJSON = Aeson.toJSON . show . int64leValue

--- a/library/Rattletrap/Type/Vector.hs
+++ b/library/Rattletrap/Type/Vector.hs
@@ -11,9 +11,16 @@ import Rattletrap.Type.CompressedWord
 data Vector = Vector
   { vectorSize :: CompressedWord
   , vectorBias :: Word
+  -- ^ This field is guaranteed to be small. In other words, it won't overflow.
+  -- It's stored as a regular 'Word' rather than something more precise like a
+  -- 'Word8' because it just gets passed to a functions that expect 'Word's.
+  -- There's no reason to do a bunch of conversions.
   , vectorX :: Int
+  -- ^ See 'vectorBias'.
   , vectorY :: Int
+  -- ^ See 'vectorBias'.
   , vectorZ :: Int
+  -- ^ See 'vectorBias'.
   } deriving (Eq, Ord, Show)
 
 $(deriveJson ''Vector)

--- a/library/Rattletrap/Type/Word64le.hs
+++ b/library/Rattletrap/Type/Word64le.hs
@@ -1,14 +1,28 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Word64le
   ( Word64le(..)
   )
 where
 
-import Rattletrap.Type.Common
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.Scientific as Scientific
+import qualified Data.Text as Text
+import qualified Data.Word as Word
+import qualified Text.Read as Read
 
 newtype Word64le = Word64le
-  { word64leValue :: Word64
+  { word64leValue :: Word.Word64
   } deriving (Eq, Ord, Show)
 
-$(deriveJson ''Word64le)
+instance Aeson.FromJSON Word64le where
+  parseJSON value = case value of
+    Aeson.String text -> case Read.readEither $ Text.unpack text of
+      Left _ -> Aeson.typeMismatch "Word64le" value
+      Right word64 -> pure $ Word64le word64
+    Aeson.Number number -> case Scientific.toBoundedInteger number of
+      Nothing -> Aeson.typeMismatch "Word64le" value
+      Just word64 -> pure $ Word64le word64
+    _ -> Aeson.typeMismatch "Word64le" value
+
+instance Aeson.ToJSON Word64le where
+  toJSON = Aeson.toJSON . show . word64leValue

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -31,6 +31,7 @@ common basics
     filepath ^>= 1.4.2,
     http-client ^>= 0.5.14,
     http-client-tls ^>= 0.3.5,
+    scientific ^>= 0.3.6,
     template-haskell ^>= 2.14.0,
     text ^>= 1.2.3,
     transformers ^>= 0.5.6,


### PR DESCRIPTION
Fixes #117. Breaking change.

This changes how all 64-bit integers (both signed and unsigned) are serialized in JSON. Instead of encoding them as numbers (like `123`), they are now encoded as strings (like `"123"`). This makes it possible for languages like JavaScript to natively deal with these numbers without losing precision (see #56). 

When decoding, both strings and numbers are accepted. That allows newer versions of Rattletrap to continue to parse JSON emitted by older versions. 