### PR TITLE
Bump http-client and template-haskell upper bounds

### DIFF
--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -29,10 +29,10 @@ common basics
     bytestring ^>= 0.10.8,
     containers >= 0.5.11 && < 0.7,
     filepath ^>= 1.4.2,
-    http-client ^>= 0.5.13,
+    http-client >= 0.5 && < 0.7,
     http-client-tls ^>= 0.3.5,
     scientific ^>= 0.3.6,
-    template-haskell ^>= 2.13.0,
+    template-haskell >= 2.13 && < 2.15,
     text ^>= 1.2.3,
     transformers ^>= 0.5.5,
   default-language: Haskell2010


### PR DESCRIPTION
Restrictive upper bounds on 'http-client' and 'template-haskell' prevent 'rattletrap' from compiling with the LTS-14.x package set; bumping these bounds addresses this.