### PR TITLE
Compute stream size when encoding frames

### DIFF
--- a/src/lib/Rattletrap/Encode/Content.hs
+++ b/src/lib/Rattletrap/Encode/Content.hs
@@ -19,18 +19,33 @@ import Rattletrap.Utility.Bytes
 import qualified Data.Binary as Binary
 import qualified Data.Binary.Bits.Put as BinaryBits
 import qualified Data.Binary.Put as Binary
+import qualified Data.ByteString as Bytes
 import qualified Data.ByteString.Lazy as LazyBytes
 
 putContent :: Content -> Binary.Put
 putContent content = do
   putList putText (contentLevels content)
   putList putKeyFrame (contentKeyFrames content)
-  let streamSize = contentStreamSize content
-  putWord32 streamSize
   let
     stream = LazyBytes.toStrict
       (Binary.runPut (BinaryBits.runBitPut (putFrames (contentFrames content)))
       )
+    -- This is a little strange. When parsing a binary replay, the stream size
+    -- is given before the stream itself. When generating the JSON, the stream
+    -- size is included. That allows a bit-for-bit identical binary replay to
+    -- be generated from the JSON. However if you modify the JSON before
+    -- converting it back into binary, the stream size might be different.
+    --
+    -- If it was possible to know how much padding the stream required without
+    -- carrying it along as extra data on the side, this logic could go away.
+    -- Unforunately that isn't currently known. See this issue for details:
+    -- <https://github.com/tfausak/rattletrap/issues/171>.
+    expectedStreamSize = contentStreamSize content
+    actualStreamSize = Word32le . fromIntegral $ Bytes.length stream
+    streamSize = Word32le $ max
+      (word32leValue expectedStreamSize)
+      (word32leValue actualStreamSize)
+  putWord32 streamSize
   Binary.putByteString
     (reverseBytes (padBytes (word32leValue streamSize) stream))
   putList putMessage (contentMessages content)


### PR DESCRIPTION
This PR fixes #171. 

Ideally the stream size would not be present in the JSON at all, or it would be ignored like the section size and CRC. However I don't currently know how to determine how much padding the stream should have. 