### PR TITLE
Allow skipping CRC

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,6 @@
 # https://github.com/ndmitchell/hlint
 - extensions:
   - default: false
-  - name: TemplateHaskell
 - flags:
   - default: false
 - group: { name: dollar, enabled: true }

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -46,6 +46,7 @@ library
     Rattletrap.BitPut
     Rattletrap.ByteGet
     Rattletrap.BytePut
+    Rattletrap.Console.Config
     Rattletrap.Console.Main
     Rattletrap.Console.Mode
     Rattletrap.Data

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -37,6 +37,7 @@ library
     , template-haskell >= 2.16.0 && < 2.17
     , text >= 1.2.4 && < 1.3
     , transformers >= 0.5.6 && < 0.6
+  default-extensions: TemplateHaskell
   default-language: Haskell2010
   exposed-modules:
     Paths_rattletrap

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -50,6 +50,7 @@ library
     Rattletrap.Console.Flag
     Rattletrap.Console.Main
     Rattletrap.Console.Mode
+    Rattletrap.Console.Option
     Rattletrap.Data
     Rattletrap.Get
     Rattletrap.Type.Attribute

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -133,6 +133,7 @@ library
     Rattletrap.Type.U64
     Rattletrap.Type.U8
     Rattletrap.Type.Vector
+    Rattletrap.Type.Version
     Rattletrap.Utility.Bytes
     Rattletrap.Utility.Crc
     Rattletrap.Utility.Helper

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -47,6 +47,7 @@ library
     Rattletrap.ByteGet
     Rattletrap.BytePut
     Rattletrap.Console.Main
+    Rattletrap.Console.Mode
     Rattletrap.Data
     Rattletrap.Get
     Rattletrap.Type.Attribute

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -47,6 +47,7 @@ library
     Rattletrap.ByteGet
     Rattletrap.BytePut
     Rattletrap.Console.Config
+    Rattletrap.Console.Flag
     Rattletrap.Console.Main
     Rattletrap.Console.Mode
     Rattletrap.Data

--- a/src/lib/Rattletrap/Console/Config.hs
+++ b/src/lib/Rattletrap/Console/Config.hs
@@ -1,0 +1,38 @@
+module Rattletrap.Console.Config where
+
+import qualified Rattletrap.Console.Mode as Mode
+import qualified System.FilePath as FilePath
+
+data Config = Config
+  { compact :: Bool
+  , fast :: Bool
+  , help :: Bool
+  , input :: Maybe String
+  , mode :: Maybe Mode.Mode
+  , output :: Maybe String
+  , version :: Bool
+  }
+  deriving (Eq, Show)
+
+initial :: Config
+initial = Config
+  { compact = False
+  , fast = False
+  , help = False
+  , input = Nothing
+  , mode = Nothing
+  , output = Nothing
+  , version = False
+  }
+
+getMode :: Config -> Mode.Mode
+getMode config =
+  let
+    i = FilePath.takeExtension <$> input config
+    o = FilePath.takeExtension <$> output config
+  in case (i, o) of
+    (Just ".json", _) -> Mode.Encode
+    (Just ".replay", _) -> Mode.Decode
+    (_, Just ".json") -> Mode.Decode
+    (_, Just ".replay") -> Mode.Encode
+    _ -> Mode.Decode

--- a/src/lib/Rattletrap/Console/Config.hs
+++ b/src/lib/Rattletrap/Console/Config.hs
@@ -1,5 +1,6 @@
 module Rattletrap.Console.Config where
 
+import qualified Rattletrap.Console.Flag as Flag
 import qualified Rattletrap.Console.Mode as Mode
 import qualified System.FilePath as FilePath
 
@@ -24,6 +25,18 @@ initial = Config
   , output = Nothing
   , version = False
   }
+
+applyFlag :: Config -> Flag.Flag -> Either String Config
+applyFlag config flag = case flag of
+  Flag.Compact -> Right config { compact = True }
+  Flag.Fast -> Right config { fast = True }
+  Flag.Help -> Right config { help = True }
+  Flag.Input x -> Right config { input = Just x }
+  Flag.Mode x -> do
+    y <- Mode.fromString x
+    Right config { mode = Just y }
+  Flag.Output x -> Right config { output = Just x }
+  Flag.Version -> Right config { version = True }
 
 getMode :: Config -> Mode.Mode
 getMode config =

--- a/src/lib/Rattletrap/Console/Config.hs
+++ b/src/lib/Rattletrap/Console/Config.hs
@@ -11,6 +11,7 @@ data Config = Config
   , input :: Maybe String
   , mode :: Maybe Mode.Mode
   , output :: Maybe String
+  , skipCrc :: Bool
   , version :: Bool
   }
   deriving (Eq, Show)
@@ -23,6 +24,7 @@ initial = Config
   , input = Nothing
   , mode = Nothing
   , output = Nothing
+  , skipCrc = False
   , version = False
   }
 
@@ -36,6 +38,7 @@ applyFlag config flag = case flag of
     y <- Mode.fromString x
     Right config { mode = Just y }
   Flag.Output x -> Right config { output = Just x }
+  Flag.SkipCrc -> Right config { skipCrc = True }
   Flag.Version -> Right config { version = True }
 
 getMode :: Config -> Mode.Mode

--- a/src/lib/Rattletrap/Console/Flag.hs
+++ b/src/lib/Rattletrap/Console/Flag.hs
@@ -1,0 +1,11 @@
+module Rattletrap.Console.Flag where
+
+data Flag
+  = Compact
+  | Fast
+  | Help
+  | Input FilePath
+  | Mode String
+  | Output FilePath
+  | Version
+  deriving (Eq, Show)

--- a/src/lib/Rattletrap/Console/Flag.hs
+++ b/src/lib/Rattletrap/Console/Flag.hs
@@ -7,5 +7,6 @@ data Flag
   | Input FilePath
   | Mode String
   | Output FilePath
+  | SkipCrc
   | Version
   deriving (Eq, Show)

--- a/src/lib/Rattletrap/Console/Main.hs
+++ b/src/lib/Rattletrap/Console/Main.hs
@@ -43,12 +43,12 @@ rattletrap name arguments = do
   let encode = getEncoder config
   putOutput config (encode replay)
 
-getDecoder :: Config.Config -> Bytes.ByteString -> Either String Replay.FullReplay
+getDecoder :: Config.Config -> Bytes.ByteString -> Either String Replay.Replay
 getDecoder config = case Config.getMode config of
   Mode.Decode -> Rattletrap.decodeReplayFile $ Config.fast config
   Mode.Encode -> Rattletrap.decodeReplayJson
 
-getEncoder :: Config.Config -> Replay.FullReplay -> Bytes.ByteString
+getEncoder :: Config.Config -> Replay.Replay -> Bytes.ByteString
 getEncoder config = case Config.getMode config of
   Mode.Decode -> if Config.compact config
     then LazyBytes.toStrict . Json.encode

--- a/src/lib/Rattletrap/Console/Main.hs
+++ b/src/lib/Rattletrap/Console/Main.hs
@@ -45,7 +45,7 @@ rattletrap name arguments = do
 
 getDecoder :: Config.Config -> Bytes.ByteString -> Either String Replay.Replay
 getDecoder config = case Config.getMode config of
-  Mode.Decode -> Rattletrap.decodeReplayFile $ Config.fast config
+  Mode.Decode -> Rattletrap.decodeReplayFile (Config.fast config) (Config.skipCrc config)
   Mode.Encode -> Rattletrap.decodeReplayJson
 
 getEncoder :: Config.Config -> Replay.Replay -> Bytes.ByteString

--- a/src/lib/Rattletrap/Console/Main.hs
+++ b/src/lib/Rattletrap/Console/Main.hs
@@ -12,8 +12,8 @@ import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Client.TLS as Client
 import qualified Paths_rattletrap as This
 import qualified Rattletrap.Console.Config as Config
-import qualified Rattletrap.Console.Flag as Flag
 import qualified Rattletrap.Console.Mode as Mode
+import qualified Rattletrap.Console.Option as Option
 import qualified Rattletrap.Type.Replay as Replay
 import qualified Rattletrap.Utility.Helper as Rattletrap
 import qualified System.Console.GetOpt as Console
@@ -68,83 +68,12 @@ getConfig :: [String] -> IO Config.Config
 getConfig arguments = do
   let
     (flags, unexpectedArguments, unknownOptions, problems) =
-      Console.getOpt' Console.Permute options arguments
+      Console.getOpt' Console.Permute Option.all arguments
   printUnexpectedArguments unexpectedArguments
   printUnknownOptions unknownOptions
   printProblems problems
   Monad.unless (null problems) Exit.exitFailure
   either fail pure (Monad.foldM Config.applyFlag Config.initial flags)
-
-type Option = Console.OptDescr Flag.Flag
-
-options :: [Option]
-options =
-  [ compactOption
-  , fastOption
-  , helpOption
-  , inputOption
-  , modeOption
-  , outputOption
-  , versionOption
-  ]
-
-compactOption :: Option
-compactOption = Console.Option
-  ['c']
-  ["compact"]
-  (Console.NoArg Flag.Compact)
-  "minify JSON output"
-
-fastOption :: Option
-fastOption = Console.Option
-  ['f']
-  ["fast"]
-  (Console.NoArg Flag.Fast)
-  "only encode or decode the header"
-
-helpOption :: Option
-helpOption = Console.Option
-  ['h']
-  ["help"]
-  (Console.NoArg Flag.Help)
-  "show the help"
-
-inputOption :: Option
-inputOption = Console.Option
-  ['i']
-  ["input"]
-  (Console.ReqArg
-    Flag.Input
-    "FILE|URL"
-  )
-  "input file or URL"
-
-modeOption :: Option
-modeOption = Console.Option
-  ['m']
-  ["mode"]
-  (Console.ReqArg
-    Flag.Mode
-    "MODE"
-  )
-  "decode or encode"
-
-outputOption :: Option
-outputOption = Console.Option
-  ['o']
-  ["output"]
-  (Console.ReqArg
-    Flag.Output
-    "FILE"
-  )
-  "output file"
-
-versionOption :: Option
-versionOption = Console.Option
-  ['v']
-  ["version"]
-  (Console.NoArg Flag.Version)
-  "show the version"
 
 printUnexpectedArguments :: [String] -> IO ()
 printUnexpectedArguments = mapM_ printUnexpectedArgument
@@ -169,7 +98,7 @@ printHelp :: String -> IO ()
 printHelp = warn . help
 
 help :: String -> String
-help name = Console.usageInfo (header name) options
+help name = Console.usageInfo (header name) Option.all
 
 header :: String -> String
 header name = unwords [name, "version", version]

--- a/src/lib/Rattletrap/Console/Mode.hs
+++ b/src/lib/Rattletrap/Console/Mode.hs
@@ -1,0 +1,12 @@
+module Rattletrap.Console.Mode where
+
+data Mode
+  = Decode
+  | Encode
+  deriving (Eq, Show)
+
+fromString :: String -> Either String Mode
+fromString string = case string of
+  "decode" -> Right Decode
+  "encode" -> Right Encode
+  _ -> Left $ "invalid mode: " <> show string

--- a/src/lib/Rattletrap/Console/Option.hs
+++ b/src/lib/Rattletrap/Console/Option.hs
@@ -1,0 +1,75 @@
+module Rattletrap.Console.Option where
+
+import qualified Rattletrap.Console.Flag as Flag
+import qualified System.Console.GetOpt as Console
+
+type Option = Console.OptDescr Flag.Flag
+
+all :: [Option]
+all =
+  [ compact
+  , fast
+  , help
+  , input
+  , mode
+  , output
+  , version
+  ]
+
+compact :: Option
+compact = Console.Option
+  ['c']
+  ["compact"]
+  (Console.NoArg Flag.Compact)
+  "minify JSON output"
+
+fast :: Option
+fast = Console.Option
+  ['f']
+  ["fast"]
+  (Console.NoArg Flag.Fast)
+  "only encode or decode the header"
+
+help :: Option
+help = Console.Option
+  ['h']
+  ["help"]
+  (Console.NoArg Flag.Help)
+  "show the help"
+
+input :: Option
+input = Console.Option
+  ['i']
+  ["input"]
+  (Console.ReqArg
+    Flag.Input
+    "FILE|URL"
+  )
+  "input file or URL"
+
+mode :: Option
+mode = Console.Option
+  ['m']
+  ["mode"]
+  (Console.ReqArg
+    Flag.Mode
+    "MODE"
+  )
+  "decode or encode"
+
+output :: Option
+output = Console.Option
+  ['o']
+  ["output"]
+  (Console.ReqArg
+    Flag.Output
+    "FILE"
+  )
+  "output file"
+
+version :: Option
+version = Console.Option
+  ['v']
+  ["version"]
+  (Console.NoArg Flag.Version)
+  "show the version"

--- a/src/lib/Rattletrap/Console/Option.hs
+++ b/src/lib/Rattletrap/Console/Option.hs
@@ -13,6 +13,7 @@ all =
   , input
   , mode
   , output
+  , skipCrc
   , version
   ]
 
@@ -66,6 +67,13 @@ output = Console.Option
     "FILE"
   )
   "output file"
+
+skipCrc :: Option
+skipCrc = Console.Option
+  []
+  ["skip-crc"]
+  (Console.NoArg Flag.SkipCrc)
+  "skips the CRC"
 
 version :: Option
 version = Console.Option

--- a/src/lib/Rattletrap/Type/Attribute.hs
+++ b/src/lib/Rattletrap/Type/Attribute.hs
@@ -8,6 +8,7 @@ import Rattletrap.Type.Common
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 data Attribute = Attribute
   { id :: CompressedWord.CompressedWord
@@ -26,7 +27,7 @@ bitPut attribute =
     <> AttributeValue.bitPut (value attribute)
 
 bitGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -> ClassAttributeMap.ClassAttributeMap
   -> Map CompressedWord.CompressedWord U32.U32
   -> CompressedWord.CompressedWord

--- a/src/lib/Rattletrap/Type/Attribute.hs
+++ b/src/lib/Rattletrap/Type/Attribute.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/AppliedDamage.hs
+++ b/src/lib/Rattletrap/Type/Attribute/AppliedDamage.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.AppliedDamage where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/AppliedDamage.hs
+++ b/src/lib/Rattletrap/Type/Attribute/AppliedDamage.hs
@@ -6,6 +6,7 @@ import Rattletrap.Type.Common
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.U8 as U8
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 
 data AppliedDamage = AppliedDamage
   { unknown1 :: U8.U8
@@ -24,7 +25,7 @@ bitPut appliedDamageAttribute =
     <> I32.bitPut (unknown3 appliedDamageAttribute)
     <> I32.bitPut (unknown4 appliedDamageAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet AppliedDamage
+bitGet :: Version.Version -> BitGet.BitGet AppliedDamage
 bitGet version =
   AppliedDamage
     <$> U8.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/Boolean.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Boolean.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Boolean where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Byte.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Byte.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Byte where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/CamSettings.hs
+++ b/src/lib/Rattletrap/Type/Attribute/CamSettings.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.CamSettings where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/CamSettings.hs
+++ b/src/lib/Rattletrap/Type/Attribute/CamSettings.hs
@@ -4,6 +4,7 @@ import qualified Rattletrap.BitGet as BitGet
 import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.F32 as F32
+import qualified Rattletrap.Type.Version as Version
 import Rattletrap.Utility.Monad
 
 data CamSettings = CamSettings
@@ -29,7 +30,7 @@ bitPut camSettingsAttribute =
     <> F32.bitPut (swivelSpeed camSettingsAttribute)
     <> foldMap F32.bitPut (transitionSpeed camSettingsAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet CamSettings
+bitGet :: Version.Version -> BitGet.BitGet CamSettings
 bitGet version =
   CamSettings
     <$> F32.bitGet
@@ -38,4 +39,8 @@ bitGet version =
     <*> F32.bitGet
     <*> F32.bitGet
     <*> F32.bitGet
-    <*> whenMaybe (version >= (868, 20, 0)) F32.bitGet
+    <*> whenMaybe (hasTransitionSpeed version) F32.bitGet
+
+hasTransitionSpeed :: Version.Version -> Bool
+hasTransitionSpeed v =
+  Version.major v >= 868 && Version.minor v >= 20 && Version.patch v >= 0

--- a/src/lib/Rattletrap/Type/Attribute/ClubColors.hs
+++ b/src/lib/Rattletrap/Type/Attribute/ClubColors.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.ClubColors where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/CustomDemolish.hs
+++ b/src/lib/Rattletrap/Type/Attribute/CustomDemolish.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.CustomDemolish where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/CustomDemolish.hs
+++ b/src/lib/Rattletrap/Type/Attribute/CustomDemolish.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import qualified Rattletrap.Type.Attribute.Demolish as Demolish
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.I32 as I32
+import qualified Rattletrap.Type.Version as Version
 
 data CustomDemolish = CustomDemolish
   { flag :: Bool
@@ -21,6 +22,6 @@ bitPut x =
     <> I32.bitPut (Rattletrap.Type.Attribute.CustomDemolish.id x)
     <> Demolish.bitPut (demolish x)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet CustomDemolish
+bitGet :: Version.Version -> BitGet.BitGet CustomDemolish
 bitGet version =
   CustomDemolish <$> BitGet.bool <*> I32.bitGet <*> Demolish.bitGet version

--- a/src/lib/Rattletrap/Type/Attribute/DamageState.hs
+++ b/src/lib/Rattletrap/Type/Attribute/DamageState.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.DamageState where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/DamageState.hs
+++ b/src/lib/Rattletrap/Type/Attribute/DamageState.hs
@@ -6,6 +6,7 @@ import Rattletrap.Type.Common
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.U8 as U8
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 
 data DamageState = DamageState
   { unknown1 :: U8.U8
@@ -28,7 +29,7 @@ bitPut damageStateAttribute =
     <> BitPut.bool (unknown5 damageStateAttribute)
     <> BitPut.bool (unknown6 damageStateAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet DamageState
+bitGet :: Version.Version -> BitGet.BitGet DamageState
 bitGet version =
   DamageState
     <$> U8.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/Demolish.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Demolish.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 
 data Demolish = Demolish
   { attackerFlag :: Bool
@@ -27,7 +28,7 @@ bitPut demolishAttribute =
     <> Vector.bitPut (attackerVelocity demolishAttribute)
     <> Vector.bitPut (victimVelocity demolishAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet Demolish
+bitGet :: Version.Version -> BitGet.BitGet Demolish
 bitGet version =
   Demolish
     <$> BitGet.bool

--- a/src/lib/Rattletrap/Type/Attribute/Demolish.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Demolish.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Demolish where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Enum.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Enum.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Enum where
 
 import Prelude hiding (Enum)

--- a/src/lib/Rattletrap/Type/Attribute/Explosion.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Explosion.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 
 data Explosion = Explosion
   { flag :: Bool
@@ -21,6 +22,6 @@ bitPut explosionAttribute =
     <> I32.bitPut (actorId explosionAttribute)
     <> Vector.bitPut (location explosionAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet Explosion
+bitGet :: Version.Version -> BitGet.BitGet Explosion
 bitGet version =
   Explosion <$> BitGet.bool <*> I32.bitGet <*> Vector.bitGet version

--- a/src/lib/Rattletrap/Type/Attribute/Explosion.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Explosion.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Explosion where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/ExtendedExplosion.hs
+++ b/src/lib/Rattletrap/Type/Attribute/ExtendedExplosion.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.ExtendedExplosion where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/ExtendedExplosion.hs
+++ b/src/lib/Rattletrap/Type/Attribute/ExtendedExplosion.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import qualified Rattletrap.Type.Attribute.Explosion as Explosion
 import qualified Rattletrap.Type.Attribute.FlaggedInt as FlaggedInt
 import Rattletrap.Type.Common
+import qualified Rattletrap.Type.Version as Version
 
 data ExtendedExplosion = ExtendedExplosion
   { explosion :: Explosion.Explosion
@@ -17,6 +18,6 @@ $(deriveJson ''ExtendedExplosion)
 bitPut :: ExtendedExplosion -> BitPut.BitPut
 bitPut x = Explosion.bitPut (explosion x) <> FlaggedInt.bitPut (unknown x)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet ExtendedExplosion
+bitGet :: Version.Version -> BitGet.BitGet ExtendedExplosion
 bitGet version =
   ExtendedExplosion <$> Explosion.bitGet version <*> FlaggedInt.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/FlaggedByte.hs
+++ b/src/lib/Rattletrap/Type/Attribute/FlaggedByte.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.FlaggedByte where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/FlaggedInt.hs
+++ b/src/lib/Rattletrap/Type/Attribute/FlaggedInt.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.FlaggedInt where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Float.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Float.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Float where
 
 import Prelude hiding (Float)

--- a/src/lib/Rattletrap/Type/Attribute/GameMode.hs
+++ b/src/lib/Rattletrap/Type/Attribute/GameMode.hs
@@ -3,6 +3,7 @@ module Rattletrap.Type.Attribute.GameMode where
 import qualified Rattletrap.BitGet as BitGet
 import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
+import qualified Rattletrap.Type.Version as Version
 
 data GameMode = GameMode
   { numBits :: Int
@@ -20,9 +21,13 @@ bitPut :: GameMode -> BitPut.BitPut
 bitPut gameModeAttribute = do
   BitPut.word8 (numBits gameModeAttribute) (word gameModeAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet GameMode
+bitGet :: Version.Version -> BitGet.BitGet GameMode
 bitGet version =
   GameMode (numBits_ version) <$> BitGet.word8 (numBits_ version)
 
-numBits_ :: (Int, Int, Int) -> Int
-numBits_ version = if version >= (868, 12, 0) then 8 else 2
+numBits_ :: Version.Version -> Int
+numBits_ version = if has8Bits version then 8 else 2
+
+has8Bits :: Version.Version -> Bool
+has8Bits v =
+  Version.major v >= 868 && Version.minor v >= 12 && Version.patch v >= 0

--- a/src/lib/Rattletrap/Type/Attribute/GameMode.hs
+++ b/src/lib/Rattletrap/Type/Attribute/GameMode.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.GameMode where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Int.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Int.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Int where
 
 import Prelude hiding (Int)

--- a/src/lib/Rattletrap/Type/Attribute/Int64.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Int64.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Int64 where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Loadout.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Loadout.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Loadout where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/LoadoutOnline.hs
+++ b/src/lib/Rattletrap/Type/Attribute/LoadoutOnline.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.LoadoutOnline where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/LoadoutOnline.hs
+++ b/src/lib/Rattletrap/Type/Attribute/LoadoutOnline.hs
@@ -8,6 +8,7 @@ import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.U8 as U8
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Data.Map as Map
 
@@ -25,7 +26,7 @@ bitPut loadoutAttribute =
       <> foldMap Product.putProductAttributes attributes
 
 bitGet
-  :: (Int, Int, Int) -> Map.Map U32.U32 Str.Str -> BitGet.BitGet LoadoutOnline
+  :: Version.Version -> Map.Map U32.U32 Str.Str -> BitGet.BitGet LoadoutOnline
 bitGet version objectMap = do
   size <- U8.bitGet
   LoadoutOnline <$> List.replicateM

--- a/src/lib/Rattletrap/Type/Attribute/Loadouts.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Loadouts.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Loadouts where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/LoadoutsOnline.hs
+++ b/src/lib/Rattletrap/Type/Attribute/LoadoutsOnline.hs
@@ -6,6 +6,7 @@ import qualified Rattletrap.Type.Attribute.LoadoutOnline as LoadoutOnline
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Data.Map as Map
 
@@ -27,7 +28,7 @@ bitPut loadoutsOnlineAttribute =
     <> BitPut.bool (unknown2 loadoutsOnlineAttribute)
 
 bitGet
-  :: (Int, Int, Int) -> Map.Map U32.U32 Str.Str -> BitGet.BitGet LoadoutsOnline
+  :: Version.Version -> Map.Map U32.U32 Str.Str -> BitGet.BitGet LoadoutsOnline
 bitGet version objectMap =
   LoadoutsOnline
     <$> LoadoutOnline.bitGet version objectMap

--- a/src/lib/Rattletrap/Type/Attribute/LoadoutsOnline.hs
+++ b/src/lib/Rattletrap/Type/Attribute/LoadoutsOnline.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.LoadoutsOnline where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Location.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Location.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Location where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Location.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Location.hs
@@ -4,6 +4,7 @@ import qualified Rattletrap.BitGet as BitGet
 import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 
 newtype Location = Location
   { value :: Vector.Vector
@@ -14,5 +15,5 @@ $(deriveJson ''Location)
 bitPut :: Location -> BitPut.BitPut
 bitPut locationAttribute = Vector.bitPut (value locationAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet Location
+bitGet :: Version.Version -> BitGet.BitGet Location
 bitGet version = Location <$> Vector.bitGet version

--- a/src/lib/Rattletrap/Type/Attribute/MusicStinger.hs
+++ b/src/lib/Rattletrap/Type/Attribute/MusicStinger.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.MusicStinger where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/PartyLeader.hs
+++ b/src/lib/Rattletrap/Type/Attribute/PartyLeader.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.PartyLeader where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/PartyLeader.hs
+++ b/src/lib/Rattletrap/Type/Attribute/PartyLeader.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.RemoteId as RemoteId
 import qualified Rattletrap.Type.U8 as U8
+import qualified Rattletrap.Type.Version as Version
 import Rattletrap.Utility.Monad
 
 data PartyLeader = PartyLeader
@@ -20,7 +21,7 @@ bitPut x = U8.bitPut (systemId x) <> foldMap
   (\(y, z) -> RemoteId.bitPut y <> U8.bitPut z)
   (Rattletrap.Type.Attribute.PartyLeader.id x)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet PartyLeader
+bitGet :: Version.Version -> BitGet.BitGet PartyLeader
 bitGet version = do
   systemId_ <- U8.bitGet
   PartyLeader systemId_ <$> whenMaybe

--- a/src/lib/Rattletrap/Type/Attribute/Pickup.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Pickup.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Pickup where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/PickupNew.hs
+++ b/src/lib/Rattletrap/Type/Attribute/PickupNew.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.PickupNew where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/PlayerHistoryKey.hs
+++ b/src/lib/Rattletrap/Type/Attribute/PlayerHistoryKey.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.PlayerHistoryKey where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/PrivateMatchSettings.hs
+++ b/src/lib/Rattletrap/Type/Attribute/PrivateMatchSettings.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.PrivateMatchSettings where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Product.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Product.hs
@@ -8,6 +8,7 @@ import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.U8 as U8
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Data.Map as Map
 
@@ -34,14 +35,14 @@ bitPut attribute =
     <> ProductValue.bitPut (value attribute)
 
 decodeProductAttributesBits
-  :: (Int, Int, Int)
+  :: Version.Version
   -> Map U32.U32 Str.Str
   -> BitGet.BitGet (List.List Product)
 decodeProductAttributesBits version objectMap = do
   size <- U8.bitGet
   List.replicateM (fromIntegral $ U8.toWord8 size) $ bitGet version objectMap
 
-bitGet :: (Int, Int, Int) -> Map U32.U32 Str.Str -> BitGet.BitGet Product
+bitGet :: Version.Version -> Map U32.U32 Str.Str -> BitGet.BitGet Product
 bitGet version objectMap = do
   flag <- BitGet.bool
   objectId_ <- U32.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/Product.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Product.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Product where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/ProductValue.hs
+++ b/src/lib/Rattletrap/Type/Attribute/ProductValue.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.ProductValue where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/QWord.hs
+++ b/src/lib/Rattletrap/Type/Attribute/QWord.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.QWord where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Reservation.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Reservation.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Reservation where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/RigidBodyState.hs
+++ b/src/lib/Rattletrap/Type/Attribute/RigidBodyState.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.RigidBodyState where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/RigidBodyState.hs
+++ b/src/lib/Rattletrap/Type/Attribute/RigidBodyState.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.Rotation as Rotation
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 import Rattletrap.Utility.Monad
 
 data RigidBodyState = RigidBodyState
@@ -26,7 +27,7 @@ bitPut rigidBodyStateAttribute =
     <> foldMap Vector.bitPut (linearVelocity rigidBodyStateAttribute)
     <> foldMap Vector.bitPut (angularVelocity rigidBodyStateAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet RigidBodyState
+bitGet :: Version.Version -> BitGet.BitGet RigidBodyState
 bitGet version = do
   sleeping_ <- BitGet.bool
   RigidBodyState sleeping_

--- a/src/lib/Rattletrap/Type/Attribute/StatEvent.hs
+++ b/src/lib/Rattletrap/Type/Attribute/StatEvent.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.StatEvent where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/String.hs
+++ b/src/lib/Rattletrap/Type/Attribute/String.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.String where
 
 import Prelude hiding (String)

--- a/src/lib/Rattletrap/Type/Attribute/TeamPaint.hs
+++ b/src/lib/Rattletrap/Type/Attribute/TeamPaint.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.TeamPaint where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/Title.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Title.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.Title where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/UniqueId.hs
+++ b/src/lib/Rattletrap/Type/Attribute/UniqueId.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.RemoteId as RemoteId
 import qualified Rattletrap.Type.U8 as U8
+import qualified Rattletrap.Type.Version as Version
 
 data UniqueId = UniqueId
   { systemId :: U8.U8
@@ -21,7 +22,7 @@ bitPut uniqueIdAttribute =
     <> RemoteId.bitPut (remoteId uniqueIdAttribute)
     <> U8.bitPut (localId uniqueIdAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet UniqueId
+bitGet :: Version.Version -> BitGet.BitGet UniqueId
 bitGet version = do
   systemId_ <- U8.bitGet
   UniqueId systemId_ <$> RemoteId.bitGet version systemId_ <*> U8.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/UniqueId.hs
+++ b/src/lib/Rattletrap/Type/Attribute/UniqueId.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.UniqueId where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/WeldedInfo.hs
+++ b/src/lib/Rattletrap/Type/Attribute/WeldedInfo.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Attribute.WeldedInfo where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Attribute/WeldedInfo.hs
+++ b/src/lib/Rattletrap/Type/Attribute/WeldedInfo.hs
@@ -7,6 +7,7 @@ import qualified Rattletrap.Type.F32 as F32
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.Int8Vector as Int8Vector
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 
 data WeldedInfo = WeldedInfo
   { active :: Bool
@@ -27,7 +28,7 @@ bitPut weldedInfoAttribute =
     <> F32.bitPut (mass weldedInfoAttribute)
     <> Int8Vector.bitPut (rotation weldedInfoAttribute)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet WeldedInfo
+bitGet :: Version.Version -> BitGet.BitGet WeldedInfo
 bitGet version =
   WeldedInfo
     <$> BitGet.bool

--- a/src/lib/Rattletrap/Type/AttributeMapping.hs
+++ b/src/lib/Rattletrap/Type/AttributeMapping.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.AttributeMapping where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/AttributeType.hs
+++ b/src/lib/Rattletrap/Type/AttributeType.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.AttributeType where
 
 import Rattletrap.Type.Common

--- a/src/lib/Rattletrap/Type/AttributeValue.hs
+++ b/src/lib/Rattletrap/Type/AttributeValue.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.AttributeValue where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/AttributeValue.hs
+++ b/src/lib/Rattletrap/Type/AttributeValue.hs
@@ -44,6 +44,7 @@ import qualified Rattletrap.Type.AttributeType as AttributeType
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Data.Map as Map
 
@@ -130,7 +131,7 @@ bitPut value = case value of
   WeldedInfo x -> WeldedInfo.bitPut x
 
 bitGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -> Map U32.U32 Str.Str
   -> Str.Str
   -> BitGet.BitGet AttributeValue

--- a/src/lib/Rattletrap/Type/Cache.hs
+++ b/src/lib/Rattletrap/Type/Cache.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Cache where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/ClassMapping.hs
+++ b/src/lib/Rattletrap/Type/ClassMapping.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.ClassMapping where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/CompressedWord.hs
+++ b/src/lib/Rattletrap/Type/CompressedWord.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.CompressedWord where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/CompressedWordVector.hs
+++ b/src/lib/Rattletrap/Type/CompressedWordVector.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.CompressedWordVector where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -22,8 +22,10 @@ import qualified Control.Monad.Trans.State as State
 import qualified Data.ByteString as Bytes
 import qualified Data.ByteString.Lazy as LazyBytes
 
+type Content = ContentWith (List.List Frame.Frame)
+
 -- | Contains low-level game data about a 'Rattletrap.Replay.Replay'.
-data Content = Content
+data ContentWith frames = Content
   { levels :: List.List Str.Str
   -- ^ This typically only has one element, like @stadium_oob_audio_map@.
   , keyFrames :: List.List KeyFrame.KeyFrame
@@ -33,7 +35,7 @@ data Content = Content
   , streamSize :: U32.U32
   -- ^ The size of the stream in bytes. This is only really necessary because
   -- the stream has some arbitrary amount of padding at the end.
-  , frames :: List.List Frame.Frame
+  , frames :: frames
   -- ^ The actual game data. This is where all the interesting information is.
   , messages :: List.List Message.Message
   -- ^ Debugging messages. In newer replays, this is always empty.
@@ -58,7 +60,7 @@ data Content = Content
   }
   deriving (Eq, Show)
 
-$(deriveJson ''Content)
+$(deriveJson ''ContentWith)
 
 empty :: Content
 empty = Content

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Content where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -15,6 +15,7 @@ import qualified Rattletrap.Type.Mark as Mark
 import qualified Rattletrap.Type.Message as Message
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 import Rattletrap.Utility.Bytes
 
 import qualified Control.Monad.Trans.State as State
@@ -112,7 +113,7 @@ putFrames x =
     (reverseBytes (padBytes (U32.toWord32 streamSize_) stream))
 
 byteGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -- ^ Version numbers, usually from 'Rattletrap.Header.getVersion'.
   -> Int
   -- ^ The number of frames in the stream, usually from

--- a/src/lib/Rattletrap/Type/F32.hs
+++ b/src/lib/Rattletrap/Type/F32.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.F32 where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Frame.hs
+++ b/src/lib/Rattletrap/Type/Frame.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Frame where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Frame.hs
+++ b/src/lib/Rattletrap/Type/Frame.hs
@@ -9,6 +9,7 @@ import qualified Rattletrap.Type.F32 as F32
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Replication as Replication
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.State as State
@@ -36,7 +37,7 @@ bitPut frame =
     <> Replication.putReplications (replications frame)
 
 decodeFramesBits
-  :: (Int, Int, Int)
+  :: Version.Version
   -> Int
   -> Word
   -> ClassAttributeMap.ClassAttributeMap
@@ -48,7 +49,7 @@ decodeFramesBits version count limit classes =
   List.replicateM count $ bitGet version limit classes
 
 bitGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -> Word
   -> ClassAttributeMap.ClassAttributeMap
   -> State.StateT

--- a/src/lib/Rattletrap/Type/Header.hs
+++ b/src/lib/Rattletrap/Type/Header.hs
@@ -59,16 +59,16 @@ data Header = Header
 
 $(deriveJson ''Header)
 
-putHeader :: Header -> BytePut.BytePut
-putHeader x =
+bytePut :: Header -> BytePut.BytePut
+bytePut x =
   U32.bytePut (engineVersion x)
     <> U32.bytePut (licenseeVersion x)
     <> foldMap U32.bytePut (patchVersion x)
     <> Str.bytePut (label x)
     <> Dictionary.bytePut Property.bytePut (properties x)
 
-decodeHeader :: ByteGet.ByteGet Header
-decodeHeader = do
+byteGet :: ByteGet.ByteGet Header
+byteGet = do
   (major, minor) <- (,) <$> U32.byteGet <*> U32.byteGet
   Header major minor
     <$> whenMaybe

--- a/src/lib/Rattletrap/Type/Header.hs
+++ b/src/lib/Rattletrap/Type/Header.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Header where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/I32.hs
+++ b/src/lib/Rattletrap/Type/I32.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.I32 where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/I8.hs
+++ b/src/lib/Rattletrap/Type/I8.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.I8 where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Initialization.hs
+++ b/src/lib/Rattletrap/Type/Initialization.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Initialization where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Initialization.hs
+++ b/src/lib/Rattletrap/Type/Initialization.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.Int8Vector as Int8Vector
 import qualified Rattletrap.Type.Vector as Vector
+import qualified Rattletrap.Type.Version as Version
 import Rattletrap.Utility.Monad
 
 data Initialization = Initialization
@@ -24,7 +25,7 @@ bitPut initialization =
   foldMap Vector.bitPut (location initialization)
     <> foldMap Int8Vector.bitPut (rotation initialization)
 
-bitGet :: (Int, Int, Int) -> Bool -> Bool -> BitGet.BitGet Initialization
+bitGet :: Version.Version -> Bool -> Bool -> BitGet.BitGet Initialization
 bitGet version hasLocation hasRotation =
   Initialization
     <$> whenMaybe hasLocation (Vector.bitGet version)

--- a/src/lib/Rattletrap/Type/Int8Vector.hs
+++ b/src/lib/Rattletrap/Type/Int8Vector.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Int8Vector where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/KeyFrame.hs
+++ b/src/lib/Rattletrap/Type/KeyFrame.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.KeyFrame where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/List.hs
+++ b/src/lib/Rattletrap/Type/List.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.List where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/Mark.hs
+++ b/src/lib/Rattletrap/Type/Mark.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Mark where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/Message.hs
+++ b/src/lib/Rattletrap/Type/Message.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Message where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/Property.hs
+++ b/src/lib/Rattletrap/Type/Property.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Property where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.PropertyValue where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/Quaternion.hs
+++ b/src/lib/Rattletrap/Type/Quaternion.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Quaternion where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/RemoteId.hs
+++ b/src/lib/Rattletrap/Type/RemoteId.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.RemoteId where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -31,11 +31,11 @@ bytePut :: Replay -> BytePut.BytePut
 bytePut x = Section.bytePut Header.bytePut (header x)
   <> Section.bytePut Content.bytePut (content x)
 
-byteGet :: Bool -> ByteGet.ByteGet Replay
-byteGet fast = do
-  hs <- Section.byteGet $ ByteGet.byteString . fromIntegral . U32.toWord32
+byteGet :: Bool -> Bool -> ByteGet.ByteGet Replay
+byteGet fast skip = do
+  hs <- Section.byteGet skip $ ByteGet.byteString . fromIntegral . U32.toWord32
   h <- either fail pure . ByteGet.run Header.byteGet $ Section.body hs
-  cs <- Section.byteGet $ ByteGet.byteString . fromIntegral . U32.toWord32
+  cs <- Section.byteGet skip $ ByteGet.byteString . fromIntegral . U32.toWord32
   c <- if fast
     then pure Content.empty
     else either fail pure . ByteGet.run (getContent h) $ Section.body cs

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -33,13 +33,13 @@ bytePut x = Section.bytePut Header.putHeader (header x)
 
 byteGet :: Bool -> ByteGet.ByteGet Replay
 byteGet fast = do
-  header_ <- Section.byteGet Header.decodeHeader
+  header_ <- Section.byteGet $ const Header.decodeHeader
   content_ <- if fast
     then pure $ Section.create Content.bytePut Content.empty
     else
       let body = Section.body header_
       in
-        Section.byteGet $ Content.byteGet
+        Section.byteGet . const $ Content.byteGet
           (getVersion body)
           (getNumFrames body)
           (getMaxChannels body)

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Replay where
 
 import qualified Rattletrap.ByteGet as ByteGet
@@ -29,9 +27,7 @@ data Replay content = Replay
 $(deriveJson ''Replay)
 
 bytePut :: FullReplay -> BytePut.BytePut
-bytePut x =
-  do
-    Section.bytePut Header.putHeader (header x)
+bytePut x = Section.bytePut Header.putHeader (header x)
   <> Section.bytePut Content.bytePut (content x)
 
 byteGet :: Bool -> ByteGet.ByteGet FullReplay

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -14,10 +14,10 @@ import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.Version as Version
 
-type FullReplay = Replay (Section.Section Header.Header) (Section.Section Content.Content)
+type Replay = ReplayWith (Section.Section Header.Header) (Section.Section Content.Content)
 
 -- | A Rocket League replay.
-data Replay header content = Replay
+data ReplayWith header content = Replay
   { header :: header
   -- ^ This has most of the high-level metadata.
   , content :: content
@@ -25,13 +25,13 @@ data Replay header content = Replay
   }
   deriving (Eq, Show)
 
-$(deriveJson ''Replay)
+$(deriveJson ''ReplayWith)
 
-bytePut :: FullReplay -> BytePut.BytePut
+bytePut :: Replay -> BytePut.BytePut
 bytePut x = Section.bytePut Header.putHeader (header x)
   <> Section.bytePut Content.bytePut (content x)
 
-byteGet :: Bool -> ByteGet.ByteGet FullReplay
+byteGet :: Bool -> ByteGet.ByteGet Replay
 byteGet fast = do
   header_ <- Section.byteGet Header.decodeHeader
   content_ <- if fast

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -12,6 +12,7 @@ import qualified Rattletrap.Type.PropertyValue as PropertyValue
 import qualified Rattletrap.Type.Section as Section
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 type FullReplay = Replay (Section.Section Header.Header) (Section.Section Content.Content)
 
@@ -44,12 +45,12 @@ byteGet fast = do
           (getMaxChannels body)
   pure $ Replay header_ content_
 
-getVersion :: Header.Header -> (Int, Int, Int)
-getVersion header_ =
-  ( fromIntegral (U32.toWord32 (Header.engineVersion header_))
-  , fromIntegral (U32.toWord32 (Header.licenseeVersion header_))
-  , getPatchVersion header_
-  )
+getVersion :: Header.Header -> Version.Version
+getVersion x = Version.Version
+  { Version.major = fromIntegral . U32.toWord32 $ Header.engineVersion x
+  , Version.minor = fromIntegral . U32.toWord32 $ Header.licenseeVersion x
+  , Version.patch = getPatchVersion x
+  }
 
 getPatchVersion :: Header.Header -> Int
 getPatchVersion header_ = case Header.patchVersion header_ of

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -13,13 +13,13 @@ import qualified Rattletrap.Type.Section as Section
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 
-type FullReplay = Replay Content.Content
+type FullReplay = Replay (Section.Section Header.Header) (Section.Section Content.Content)
 
 -- | A Rocket League replay.
-data Replay content = Replay
-  { header :: Section.Section Header.Header
+data Replay header content = Replay
+  { header :: header
   -- ^ This has most of the high-level metadata.
-  , content :: Section.Section content
+  , content :: content
   -- ^ This has most of the low-level game data.
   }
   deriving (Eq, Show)

--- a/src/lib/Rattletrap/Type/Replication.hs
+++ b/src/lib/Rattletrap/Type/Replication.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Replication where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Replication.hs
+++ b/src/lib/Rattletrap/Type/Replication.hs
@@ -8,6 +8,7 @@ import qualified Rattletrap.Type.CompressedWord as CompressedWord
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.ReplicationValue as ReplicationValue
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.State as State
@@ -31,7 +32,7 @@ bitPut replication = CompressedWord.bitPut (actorId replication)
   <> ReplicationValue.bitPut (value replication)
 
 decodeReplicationsBits
-  :: (Int, Int, Int)
+  :: Version.Version
   -> Word
   -> ClassAttributeMap.ClassAttributeMap
   -> State.StateT
@@ -43,7 +44,7 @@ decodeReplicationsBits version limit classes = List.untilM $ do
   if p then Just <$> bitGet version limit classes else pure Nothing
 
 bitGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -> Word
   -> ClassAttributeMap.ClassAttributeMap
   -> State.StateT

--- a/src/lib/Rattletrap/Type/Replication/Destroyed.hs
+++ b/src/lib/Rattletrap/Type/Replication/Destroyed.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Replication.Destroyed where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Replication/Spawned.hs
+++ b/src/lib/Rattletrap/Type/Replication/Spawned.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Replication.Spawned where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Replication/Updated.hs
+++ b/src/lib/Rattletrap/Type/Replication/Updated.hs
@@ -8,6 +8,7 @@ import Rattletrap.Type.Common
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Data.Map as Map
 
@@ -25,7 +26,7 @@ bitPut x =
     <> BitPut.bool False
 
 bitGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -> ClassAttributeMap.ClassAttributeMap
   -> Map.Map CompressedWord.CompressedWord U32.U32
   -> CompressedWord.CompressedWord

--- a/src/lib/Rattletrap/Type/Replication/Updated.hs
+++ b/src/lib/Rattletrap/Type/Replication/Updated.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Replication.Updated where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/ReplicationValue.hs
+++ b/src/lib/Rattletrap/Type/ReplicationValue.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.ReplicationValue where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/ReplicationValue.hs
+++ b/src/lib/Rattletrap/Type/ReplicationValue.hs
@@ -9,6 +9,7 @@ import qualified Rattletrap.Type.Replication.Destroyed as Destroyed
 import qualified Rattletrap.Type.Replication.Spawned as Spawned
 import qualified Rattletrap.Type.Replication.Updated as Updated
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.Type.Version as Version
 
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.State as State
@@ -32,7 +33,7 @@ bitPut value = case value of
   Destroyed x -> BitPut.bool False <> Destroyed.bitPut x
 
 bitGet
-  :: (Int, Int, Int)
+  :: Version.Version
   -> ClassAttributeMap.ClassAttributeMap
   -> CompressedWord.CompressedWord
   -> State.StateT

--- a/src/lib/Rattletrap/Type/Rotation.hs
+++ b/src/lib/Rattletrap/Type/Rotation.hs
@@ -5,6 +5,7 @@ import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.CompressedWordVector as CompressedWordVector
 import qualified Rattletrap.Type.Quaternion as Quaternion
+import qualified Rattletrap.Type.Version as Version
 
 data Rotation
   = CompressedWordVector CompressedWordVector.CompressedWordVector
@@ -18,7 +19,11 @@ bitPut r = case r of
   CompressedWordVector cwv -> CompressedWordVector.bitPut cwv
   Quaternion q -> Quaternion.bitPut q
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet Rotation
-bitGet version = if version >= (868, 22, 7)
+bitGet :: Version.Version -> BitGet.BitGet Rotation
+bitGet version = if isQuaternion version
   then Quaternion <$> Quaternion.bitGet
   else CompressedWordVector <$> CompressedWordVector.bitGet
+
+isQuaternion :: Version.Version -> Bool
+isQuaternion v =
+  Version.major v >= 868 && Version.minor v >= 22 && Version.patch v >= 7

--- a/src/lib/Rattletrap/Type/Rotation.hs
+++ b/src/lib/Rattletrap/Type/Rotation.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Rotation where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Section.hs
+++ b/src/lib/Rattletrap/Type/Section.hs
@@ -48,14 +48,14 @@ bytePut putBody section =
     <> U32.bytePut (U32.fromWord32 crc_)
     <> BytePut.byteString rawBody
 
-byteGet :: ByteGet.ByteGet a -> ByteGet.ByteGet (Section a)
+byteGet :: (U32.U32 -> ByteGet.ByteGet a) -> ByteGet.ByteGet (Section a)
 byteGet getBody = do
   size_ <- U32.byteGet
   crc_ <- U32.byteGet
   rawBody <- ByteGet.byteString (fromIntegral (U32.toWord32 size_))
   let actualCrc = U32.fromWord32 (Crc.compute rawBody)
   Monad.when (actualCrc /= crc_) (fail (crcMessage actualCrc crc_))
-  body_ <- either fail pure $ ByteGet.run getBody rawBody
+  body_ <- either fail pure $ ByteGet.run (getBody size_) rawBody
   pure (Section size_ crc_ body_)
 
 crcMessage :: U32.U32 -> U32.U32 -> String

--- a/src/lib/Rattletrap/Type/Section.hs
+++ b/src/lib/Rattletrap/Type/Section.hs
@@ -48,13 +48,14 @@ bytePut putBody section =
     <> U32.bytePut (U32.fromWord32 crc_)
     <> BytePut.byteString rawBody
 
-byteGet :: (U32.U32 -> ByteGet.ByteGet a) -> ByteGet.ByteGet (Section a)
-byteGet getBody = do
+byteGet :: Bool -> (U32.U32 -> ByteGet.ByteGet a) -> ByteGet.ByteGet (Section a)
+byteGet skip getBody = do
   size_ <- U32.byteGet
   crc_ <- U32.byteGet
   rawBody <- ByteGet.byteString (fromIntegral (U32.toWord32 size_))
-  let actualCrc = U32.fromWord32 (Crc.compute rawBody)
-  Monad.when (actualCrc /= crc_) (fail (crcMessage actualCrc crc_))
+  Monad.unless skip $ do
+    let actualCrc = U32.fromWord32 (Crc.compute rawBody)
+    Monad.when (actualCrc /= crc_) (fail (crcMessage actualCrc crc_))
   body_ <- either fail pure $ ByteGet.run (getBody size_) rawBody
   pure (Section size_ crc_ body_)
 

--- a/src/lib/Rattletrap/Type/Section.hs
+++ b/src/lib/Rattletrap/Type/Section.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Section where
 
 import qualified Rattletrap.ByteGet as ByteGet

--- a/src/lib/Rattletrap/Type/Str.hs
+++ b/src/lib/Rattletrap/Type/Str.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Str where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/U32.hs
+++ b/src/lib/Rattletrap/Type/U32.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.U32 where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/U8.hs
+++ b/src/lib/Rattletrap/Type/U8.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.U8 where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Vector.hs
+++ b/src/lib/Rattletrap/Type/Vector.hs
@@ -4,6 +4,7 @@ import qualified Rattletrap.BitGet as BitGet
 import qualified Rattletrap.BitPut as BitPut
 import Rattletrap.Type.Common
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
+import qualified Rattletrap.Type.Version as Version
 
 data Vector = Vector
   { size :: CompressedWord.CompressedWord
@@ -38,9 +39,9 @@ bitPut vector =
     <> CompressedWord.bitPut (CompressedWord.CompressedWord limit dy)
     <> CompressedWord.bitPut (CompressedWord.CompressedWord limit dz)
 
-bitGet :: (Int, Int, Int) -> BitGet.BitGet Vector
+bitGet :: Version.Version -> BitGet.BitGet Vector
 bitGet version = do
-  size_ <- CompressedWord.bitGet (if version >= (868, 22, 7) then 21 else 19)
+  size_ <- CompressedWord.bitGet (if has21Bits version then 21 else 19)
   let
     limit = getLimit size_
     bias_ = getBias size_
@@ -48,6 +49,10 @@ bitGet version = do
     <$> fmap (fromDelta bias_) (CompressedWord.bitGet limit)
     <*> fmap (fromDelta bias_) (CompressedWord.bitGet limit)
     <*> fmap (fromDelta bias_) (CompressedWord.bitGet limit)
+
+has21Bits :: Version.Version -> Bool
+has21Bits v =
+  Version.major v >= 868 && Version.minor v >= 22 && Version.patch v >= 7
 
 getLimit :: CompressedWord.CompressedWord -> Word
 getLimit = (2 ^) . (+ 2) . CompressedWord.value

--- a/src/lib/Rattletrap/Type/Vector.hs
+++ b/src/lib/Rattletrap/Type/Vector.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Rattletrap.Type.Vector where
 
 import qualified Rattletrap.BitGet as BitGet

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -1,0 +1,7 @@
+module Rattletrap.Type.Version where
+
+data Version = Version
+  { major :: Int
+  , minor :: Int
+  , patch :: Int
+  } deriving (Eq, Show)

--- a/src/lib/Rattletrap/Utility/Helper.hs
+++ b/src/lib/Rattletrap/Utility/Helper.hs
@@ -20,8 +20,8 @@ import qualified Data.ByteString.Lazy as LazyBytes
 
 -- | Parses a raw replay.
 decodeReplayFile
-  :: Bool -> Bytes.ByteString -> Either String Replay.Replay
-decodeReplayFile = ByteGet.run . Replay.byteGet
+  :: Bool -> Bool -> Bytes.ByteString -> Either String Replay.Replay
+decodeReplayFile fast = ByteGet.run . Replay.byteGet fast
 
 -- | Encodes a replay as JSON.
 encodeReplayJson :: Replay.Replay -> Bytes.ByteString

--- a/src/lib/Rattletrap/Utility/Helper.hs
+++ b/src/lib/Rattletrap/Utility/Helper.hs
@@ -20,11 +20,11 @@ import qualified Data.ByteString.Lazy as LazyBytes
 
 -- | Parses a raw replay.
 decodeReplayFile
-  :: Bool -> Bytes.ByteString -> Either String Replay.FullReplay
+  :: Bool -> Bytes.ByteString -> Either String Replay.Replay
 decodeReplayFile = ByteGet.run . Replay.byteGet
 
 -- | Encodes a replay as JSON.
-encodeReplayJson :: Replay.FullReplay -> Bytes.ByteString
+encodeReplayJson :: Replay.Replay -> Bytes.ByteString
 encodeReplayJson = LazyBytes.toStrict . Json.encodePretty' Json.defConfig
   { Json.confCompare = compare
   , Json.confIndent = Json.Spaces 2
@@ -32,11 +32,11 @@ encodeReplayJson = LazyBytes.toStrict . Json.encodePretty' Json.defConfig
   }
 
 -- | Parses a JSON replay.
-decodeReplayJson :: Bytes.ByteString -> Either String Replay.FullReplay
+decodeReplayJson :: Bytes.ByteString -> Either String Replay.Replay
 decodeReplayJson = Json.eitherDecodeStrict'
 
 -- | Encodes a raw replay.
-encodeReplayFile :: Bool -> Replay.FullReplay -> Bytes.ByteString
+encodeReplayFile :: Bool -> Replay.Replay -> Bytes.ByteString
 encodeReplayFile fast replay = BytePut.toByteString . Replay.bytePut $ if fast
   then replay { Replay.content = Section.create Content.bytePut Content.empty }
   else replay


### PR DESCRIPTION
This will fix #201. For now I've done a lot of little clean up. Actually allowing the CRC to be skipped is going to be a little involved. Here's my game plan:

- Change the section type to store an un-parsed `ByteString`. In other words it's just a wrapper around a byte string with the size and CRC. 
- Barely parse the replay into the two sections. 
- If we're checking the CRC, check it. If we're not, skip it.
- Move on to parse the header.
- Used the parsed header to inform parsing the content. 
- Optional, but nice: Do something similar with the frame parsing. Barely parse it into a "section", then use the header and other contents to parse it into the full frames if appropriate. 

In other words:

1. `Replay Section Section`
2. `Replay Header Section`
3. `Replay Header (Content Section)`
4. `Replay Header (Content Frames)`