### PR TITLE
Factor out version type

### DIFF
--- a/src/lib/Rattletrap/Type/Attribute/CamSettings.hs
+++ b/src/lib/Rattletrap/Type/Attribute/CamSettings.hs
@@ -80,7 +80,7 @@ bitGet version = do
   distance <- F32.bitGet
   stiffness <- F32.bitGet
   swivelSpeed <- F32.bitGet
-  transitionSpeed <- whenMaybe (hasTransitionSpeed version) F32.bitGet
+  transitionSpeed <- whenMaybe (Version.atLeast 868 20 0 version) F32.bitGet
   pure CamSettings
     { fov
     , height
@@ -90,7 +90,3 @@ bitGet version = do
     , swivelSpeed
     , transitionSpeed
     }
-
-hasTransitionSpeed :: Version.Version -> Bool
-hasTransitionSpeed v =
-  Version.major v >= 868 && Version.minor v >= 20 && Version.patch v >= 0

--- a/src/lib/Rattletrap/Type/Attribute/GameMode.hs
+++ b/src/lib/Rattletrap/Type/Attribute/GameMode.hs
@@ -39,10 +39,6 @@ bitPut gameModeAttribute = do
 
 bitGet :: Version.Version -> BitGet.BitGet GameMode
 bitGet version = do
-  let numBits = if has8Bits version then 8 else 2 :: Int
+  let numBits = if Version.atLeast 868 12 0 version then 8 else 2 :: Int
   word <- BitGet.word8 numBits
   pure GameMode { numBits, word }
-
-has8Bits :: Version.Version -> Bool
-has8Bits v =
-  Version.major v >= 868 && Version.minor v >= 12 && Version.patch v >= 0

--- a/src/lib/Rattletrap/Type/Attribute/ProductValue.hs
+++ b/src/lib/Rattletrap/Type/Attribute/ProductValue.hs
@@ -103,19 +103,14 @@ decodeTeamEdition version = if hasNewPainted version
   else fmap TeamEditionOld $ CompressedWord.bitGet 13
 
 decodeColor :: Version.Version -> BitGet.BitGet ProductValue
-decodeColor version = if hasNewColor version
+decodeColor version = if Version.atLeast 868 23 8 version
   then fmap UserColorNew U32.bitGet
   else do
     hasValue <- BitGet.bool
     fmap UserColorOld $ whenMaybe hasValue (BitGet.bits 31)
 
 hasNewPainted :: Version.Version -> Bool
-hasNewPainted v =
-  Version.major v >= 868 && Version.minor v >= 18 && Version.patch v >= 0
-
-hasNewColor :: Version.Version -> Bool
-hasNewColor v =
-  Version.major v >= 868 && Version.minor v >= 23 && Version.patch v >= 8
+hasNewPainted = Version.atLeast 868 10 0
 
 decodeTitle :: BitGet.BitGet ProductValue
 decodeTitle = fmap TitleId Str.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/ProductValue.hs
+++ b/src/lib/Rattletrap/Type/Attribute/ProductValue.hs
@@ -110,7 +110,7 @@ decodeColor version = if Version.atLeast 868 23 8 version
     fmap UserColorOld $ whenMaybe hasValue (BitGet.bits 31)
 
 hasNewPainted :: Version.Version -> Bool
-hasNewPainted = Version.atLeast 868 10 0
+hasNewPainted = Version.atLeast 868 18 0
 
 decodeTitle :: BitGet.BitGet ProductValue
 decodeTitle = fmap TitleId Str.bitGet

--- a/src/lib/Rattletrap/Type/Attribute/Reservation.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Reservation.hs
@@ -68,9 +68,5 @@ bitGet version = do
   name <- whenMaybe (UniqueId.systemId uniqueId /= U8.fromWord8 0) Str.bitGet
   unknown1 <- BitGet.bool
   unknown2 <- BitGet.bool
-  unknown3 <- whenMaybe (hasUnknown3 version) (BitGet.word8 6)
+  unknown3 <- whenMaybe (Version.atLeast 868 12 0 version) $ BitGet.word8 6
   pure Reservation { number, uniqueId, name, unknown1, unknown2, unknown3 }
-
-hasUnknown3 :: Version.Version -> Bool
-hasUnknown3 v =
-  Version.major v >= 868 && Version.minor v >= 12 && Version.patch v >= 0

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -180,7 +180,8 @@ putFrames x =
     (reverseBytes (padBytes (U32.toWord32 streamSize_) stream))
 
 byteGet
-  :: Version.Version
+  :: Maybe Str.Str
+  -> Version.Version
   -- ^ Version numbers, usually from 'Rattletrap.Header.getVersion'.
   -> Int
   -- ^ The number of frames in the stream, usually from
@@ -189,7 +190,7 @@ byteGet
   -- ^ The maximum number of channels in the stream, usually from
   -- 'Rattletrap.Header.getMaxChannels'.
   -> ByteGet.ByteGet Content
-byteGet version numFrames maxChannels = do
+byteGet matchType version numFrames maxChannels = do
   levels <- List.byteGet Str.byteGet
   keyframes <- List.byteGet Keyframe.byteGet
   streamSize <- U32.byteGet
@@ -205,7 +206,7 @@ byteGet version numFrames maxChannels = do
     classAttributeMap =
       ClassAttributeMap.make objects classMappings caches names
     bitGet = State.evalStateT
-      (Frame.decodeFramesBits version numFrames maxChannels classAttributeMap)
+      (Frame.decodeFramesBits matchType version numFrames maxChannels classAttributeMap)
       mempty
   frames <-
     either fail pure . ByteGet.run (BitGet.toByteGet bitGet) $ reverseBytes

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -206,7 +206,13 @@ byteGet matchType version numFrames maxChannels = do
     classAttributeMap =
       ClassAttributeMap.make objects classMappings caches names
     bitGet = State.evalStateT
-      (Frame.decodeFramesBits matchType version numFrames maxChannels classAttributeMap)
+      (Frame.decodeFramesBits
+        matchType
+        version
+        numFrames
+        maxChannels
+        classAttributeMap
+      )
       mempty
   frames <-
     either fail pure . ByteGet.run (BitGet.toByteGet bitGet) $ reverseBytes

--- a/src/lib/Rattletrap/Type/Frame.hs
+++ b/src/lib/Rattletrap/Type/Frame.hs
@@ -84,5 +84,9 @@ bitGet
 bitGet matchType version limit classes = do
   time <- Trans.lift F32.bitGet
   delta <- Trans.lift F32.bitGet
-  replications <- Replication.decodeReplicationsBits matchType version limit classes
+  replications <- Replication.decodeReplicationsBits
+    matchType
+    version
+    limit
+    classes
   pure Frame { time, delta, replications }

--- a/src/lib/Rattletrap/Type/Header.hs
+++ b/src/lib/Rattletrap/Type/Header.hs
@@ -61,7 +61,11 @@ instance Json.FromJSON Header where
     label <- Json.required object "label"
     properties <- Json.required object "properties"
     pure Header
-      { version = Version.Version { Version.major, Version.minor, Version.patch }
+      { version = Version.Version
+        { Version.major
+        , Version.minor
+        , Version.patch
+        }
       , label
       , properties
       }
@@ -88,17 +92,13 @@ schema = Schema.named "header" $ Schema.object
 
 bytePut :: Header -> BytePut.BytePut
 bytePut x =
-  Version.bytePut (version x)
-    <> Str.bytePut (label x)
-    <> Dictionary.bytePut Property.bytePut (properties x)
+  Version.bytePut (version x) <> Str.bytePut (label x) <> Dictionary.bytePut
+    Property.bytePut
+    (properties x)
 
 byteGet :: ByteGet.ByteGet Header
 byteGet = do
   version <- Version.byteGet
   label <- Str.byteGet
   properties <- Dictionary.byteGet Property.byteGet
-  pure Header
-    { version
-    , label
-    , properties
-    }
+  pure Header { version, label, properties }

--- a/src/lib/Rattletrap/Type/RemoteId.hs
+++ b/src/lib/Rattletrap/Type/RemoteId.hs
@@ -106,15 +106,11 @@ bitGet version systemId = case U8.toWord8 systemId of
   6 -> do
     (a, b, c, d) <- getWord256
     pure $ Switch a b c d
-  7 -> fmap PsyNet $ if psyNetIsU64 version
+  7 -> fmap PsyNet $ if Version.atLeast 868 24 10 version
     then fmap Left U64.bitGet
     else fmap Right getWord256
   11 -> fmap Epic Str.bitGet
   _ -> fail ("[RT09] unknown system id " <> show systemId)
-
-psyNetIsU64 :: Version.Version -> Bool
-psyNetIsU64 v =
-  Version.major v >= 868 && Version.minor v >= 24 && Version.patch v >= 10
 
 decodePsName :: BitGet.BitGet Text.Text
 decodePsName = fmap
@@ -123,13 +119,9 @@ decodePsName = fmap
 
 decodePsBytes :: Version.Version -> BitGet.BitGet [Word.Word8]
 decodePsBytes version =
-  fmap Bytes.unpack . BitGet.byteString $ if playStationIsU24 version
+  fmap Bytes.unpack . BitGet.byteString $ if Version.atLeast 868 20 1 version
     then 24
     else 16
-
-playStationIsU24 :: Version.Version -> Bool
-playStationIsU24 v =
-  Version.major v >= 868 && Version.minor v >= 20 && Version.patch v >= 1
 
 getWord256 :: BitGet.BitGet (U64.U64, U64.U64, U64.U64, U64.U64)
 getWord256 = do

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -77,7 +77,14 @@ byteGet fast skip = do
 
 getContent :: Header.Header -> ByteGet.ByteGet Content.Content
 getContent h =
-  Content.byteGet (getVersion h) (getNumFrames h) (getMaxChannels h)
+  Content.byteGet (getMatchType h) (getVersion h) (getNumFrames h) (getMaxChannels h)
+
+getMatchType :: Header.Header -> Maybe Str.Str
+getMatchType header = do
+  Property.Property { Property.value } <- Dictionary.lookup (Str.fromString "MatchType") $ Header.properties header
+  case value of
+    PropertyValue.Name x -> Just x
+    _ -> Nothing
 
 getVersion :: Header.Header -> Version.Version
 getVersion x = Version.Version

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -90,23 +90,8 @@ getVersion :: Header.Header -> Version.Version
 getVersion x = Version.Version
   { Version.major = Header.engineVersion x
   , Version.minor = Header.licenseeVersion x
-  , Version.patch = getPatchVersion x
+  , Version.patch = Header.patchVersion x
   }
-
-getPatchVersion :: Header.Header -> Int
-getPatchVersion header_ = case Header.patchVersion header_ of
-  Just version -> fromIntegral (U32.toWord32 version)
-  Nothing ->
-    case
-        Dictionary.lookup
-          (Str.fromString "MatchType")
-          (Header.properties header_)
-      of
-      -- This is an ugly, ugly hack to handle replays from season 2 of RLCS.
-      -- See `decodeSpawnedReplicationBits` and #85.
-        Just Property.Property { Property.value = PropertyValue.Name str }
-          | Str.toString str == "Lan" -> -1
-        _ -> 0
 
 getNumFrames :: Header.Header -> Int
 getNumFrames header_ =

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -81,8 +81,8 @@ getContent h =
 
 getVersion :: Header.Header -> Version.Version
 getVersion x = Version.Version
-  { Version.major = fromIntegral . U32.toWord32 $ Header.engineVersion x
-  , Version.minor = fromIntegral . U32.toWord32 $ Header.licenseeVersion x
+  { Version.major = Header.engineVersion x
+  , Version.minor = Header.licenseeVersion x
   , Version.patch = getPatchVersion x
   }
 

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -75,12 +75,16 @@ byteGet fast skip = do
     }
 
 getContent :: Header.Header -> ByteGet.ByteGet Content.Content
-getContent h =
-  Content.byteGet (getMatchType h) (Header.version h) (getNumFrames h) (getMaxChannels h)
+getContent h = Content.byteGet
+  (getMatchType h)
+  (Header.version h)
+  (getNumFrames h)
+  (getMaxChannels h)
 
 getMatchType :: Header.Header -> Maybe Str.Str
 getMatchType header = do
-  Property.Property { Property.value } <- Dictionary.lookup (Str.fromString "MatchType") $ Header.properties header
+  Property.Property { Property.value } <-
+    Dictionary.lookup (Str.fromString "MatchType") $ Header.properties header
   case value of
     PropertyValue.Name x -> Just x
     _ -> Nothing

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -12,7 +12,6 @@ import qualified Rattletrap.Type.PropertyValue as PropertyValue
 import qualified Rattletrap.Type.Section as Section
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
-import qualified Rattletrap.Type.Version as Version
 import qualified Rattletrap.Utility.Json as Json
 import qualified Rattletrap.Version as Version
 
@@ -77,7 +76,7 @@ byteGet fast skip = do
 
 getContent :: Header.Header -> ByteGet.ByteGet Content.Content
 getContent h =
-  Content.byteGet (getMatchType h) (getVersion h) (getNumFrames h) (getMaxChannels h)
+  Content.byteGet (getMatchType h) (Header.version h) (getNumFrames h) (getMaxChannels h)
 
 getMatchType :: Header.Header -> Maybe Str.Str
 getMatchType header = do
@@ -85,13 +84,6 @@ getMatchType header = do
   case value of
     PropertyValue.Name x -> Just x
     _ -> Nothing
-
-getVersion :: Header.Header -> Version.Version
-getVersion x = Version.Version
-  { Version.major = Header.engineVersion x
-  , Version.minor = Header.licenseeVersion x
-  , Version.patch = Header.patchVersion x
-  }
 
 getNumFrames :: Header.Header -> Int
 getNumFrames header_ =

--- a/src/lib/Rattletrap/Type/Replication.hs
+++ b/src/lib/Rattletrap/Type/Replication.hs
@@ -58,7 +58,9 @@ decodeReplicationsBits
        (List.List Replication)
 decodeReplicationsBits matchType version limit classes = List.untilM $ do
   p <- Trans.lift BitGet.bool
-  if p then fmap Just $ bitGet matchType version limit classes else pure Nothing
+  if p
+    then fmap Just $ bitGet matchType version limit classes
+    else pure Nothing
 
 bitGet
   :: Maybe Str.Str
@@ -71,4 +73,5 @@ bitGet
        Replication
 bitGet matchType version limit classes = do
   actor <- Trans.lift (CompressedWord.bitGet limit)
-  fmap (Replication actor) $ ReplicationValue.bitGet matchType version classes actor
+  fmap (Replication actor)
+    $ ReplicationValue.bitGet matchType version classes actor

--- a/src/lib/Rattletrap/Type/Replication.hs
+++ b/src/lib/Rattletrap/Type/Replication.hs
@@ -7,6 +7,7 @@ import qualified Rattletrap.Type.ClassAttributeMap as ClassAttributeMap
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.ReplicationValue as ReplicationValue
+import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.Version as Version
 import qualified Rattletrap.Utility.Json as Json
@@ -47,25 +48,27 @@ bitPut replication = CompressedWord.bitPut (actorId replication)
   <> ReplicationValue.bitPut (value replication)
 
 decodeReplicationsBits
-  :: Version.Version
+  :: Maybe Str.Str
+  -> Version.Version
   -> Word
   -> ClassAttributeMap.ClassAttributeMap
   -> State.StateT
        (Map.Map CompressedWord.CompressedWord U32.U32)
        BitGet.BitGet
        (List.List Replication)
-decodeReplicationsBits version limit classes = List.untilM $ do
+decodeReplicationsBits matchType version limit classes = List.untilM $ do
   p <- Trans.lift BitGet.bool
-  if p then fmap Just $ bitGet version limit classes else pure Nothing
+  if p then fmap Just $ bitGet matchType version limit classes else pure Nothing
 
 bitGet
-  :: Version.Version
+  :: Maybe Str.Str
+  -> Version.Version
   -> Word
   -> ClassAttributeMap.ClassAttributeMap
   -> State.StateT
        (Map.Map CompressedWord.CompressedWord U32.U32)
        BitGet.BitGet
        Replication
-bitGet version limit classes = do
+bitGet matchType version limit classes = do
   actor <- Trans.lift (CompressedWord.bitGet limit)
-  fmap (Replication actor) $ ReplicationValue.bitGet version classes actor
+  fmap (Replication actor) $ ReplicationValue.bitGet matchType version classes actor

--- a/src/lib/Rattletrap/Type/Replication/Spawned.hs
+++ b/src/lib/Rattletrap/Type/Replication/Spawned.hs
@@ -92,7 +92,7 @@ bitGet
        Spawned
 bitGet version classAttributeMap actorId = do
   flag_ <- Trans.lift BitGet.bool
-  nameIndex_ <- whenMaybe (hasNameIndex version) (Trans.lift U32.bitGet)
+  nameIndex_ <- whenMaybe (Version.atLeast 868 14 0 version) $ Trans.lift U32.bitGet
   name_ <- either fail pure (lookupName classAttributeMap nameIndex_)
   objectId_ <- Trans.lift U32.bitGet
   State.modify (Map.insert actorId objectId_)
@@ -115,10 +115,6 @@ bitGet version classAttributeMap actorId = do
       className_
       initialization_
     )
-
-hasNameIndex :: Version.Version -> Bool
-hasNameIndex v =
-  Version.major v >= 868 && Version.minor v >= 14 && Version.patch v >= 0
 
 lookupName
   :: ClassAttributeMap.ClassAttributeMap

--- a/src/lib/Rattletrap/Type/Replication/Spawned.hs
+++ b/src/lib/Rattletrap/Type/Replication/Spawned.hs
@@ -83,16 +83,17 @@ bitPut spawnedReplication =
     <> Initialization.bitPut (initialization spawnedReplication)
 
 bitGet
-  :: Version.Version
+  :: Maybe Str.Str
+  -> Version.Version
   -> ClassAttributeMap.ClassAttributeMap
   -> CompressedWord.CompressedWord
   -> State.StateT
        (Map.Map CompressedWord.CompressedWord U32.U32)
        BitGet.BitGet
        Spawned
-bitGet version classAttributeMap actorId = do
+bitGet matchType version classAttributeMap actorId = do
   flag_ <- Trans.lift BitGet.bool
-  nameIndex_ <- whenMaybe (Version.atLeast 868 14 0 version) $ Trans.lift U32.bitGet
+  nameIndex_ <- whenMaybe (hasNameIndex matchType version) $ Trans.lift U32.bitGet
   name_ <- either fail pure (lookupName classAttributeMap nameIndex_)
   objectId_ <- Trans.lift U32.bitGet
   State.modify (Map.insert actorId objectId_)
@@ -115,6 +116,9 @@ bitGet version classAttributeMap actorId = do
       className_
       initialization_
     )
+
+hasNameIndex :: Maybe Str.Str -> Version.Version -> Bool
+hasNameIndex _ = Version.atLeast 868 14 0
 
 lookupName
   :: ClassAttributeMap.ClassAttributeMap

--- a/src/lib/Rattletrap/Type/Replication/Spawned.hs
+++ b/src/lib/Rattletrap/Type/Replication/Spawned.hs
@@ -93,7 +93,8 @@ bitGet
        Spawned
 bitGet matchType version classAttributeMap actorId = do
   flag_ <- Trans.lift BitGet.bool
-  nameIndex_ <- whenMaybe (hasNameIndex matchType version) $ Trans.lift U32.bitGet
+  nameIndex_ <- whenMaybe (hasNameIndex matchType version)
+    $ Trans.lift U32.bitGet
   name_ <- either fail pure (lookupName classAttributeMap nameIndex_)
   objectId_ <- Trans.lift U32.bitGet
   State.modify (Map.insert actorId objectId_)
@@ -118,8 +119,8 @@ bitGet matchType version classAttributeMap actorId = do
     )
 
 hasNameIndex :: Maybe Str.Str -> Version.Version -> Bool
-hasNameIndex matchType version = Version.atLeast 868 14 0 version
-  && matchType /= Just (Str.fromString "Lan")
+hasNameIndex matchType version =
+  Version.atLeast 868 14 0 version && matchType /= Just (Str.fromString "Lan")
 
 lookupName
   :: ClassAttributeMap.ClassAttributeMap

--- a/src/lib/Rattletrap/Type/Replication/Spawned.hs
+++ b/src/lib/Rattletrap/Type/Replication/Spawned.hs
@@ -118,7 +118,8 @@ bitGet matchType version classAttributeMap actorId = do
     )
 
 hasNameIndex :: Maybe Str.Str -> Version.Version -> Bool
-hasNameIndex _ = Version.atLeast 868 14 0
+hasNameIndex matchType version = Version.atLeast 868 14 0 version
+  && matchType /= Just (Str.fromString "Lan")
 
 lookupName
   :: ClassAttributeMap.ClassAttributeMap

--- a/src/lib/Rattletrap/Type/ReplicationValue.hs
+++ b/src/lib/Rattletrap/Type/ReplicationValue.hs
@@ -70,7 +70,8 @@ bitGet matchType version classAttributeMap actorId = do
     then do
       isNew <- Trans.lift BitGet.bool
       if isNew
-        then fmap Spawned $ Spawned.bitGet matchType version classAttributeMap actorId
+        then fmap Spawned
+          $ Spawned.bitGet matchType version classAttributeMap actorId
         else fmap Updated . Trans.lift $ Updated.bitGet
           version
           classAttributeMap

--- a/src/lib/Rattletrap/Type/ReplicationValue.hs
+++ b/src/lib/Rattletrap/Type/ReplicationValue.hs
@@ -8,6 +8,7 @@ import qualified Rattletrap.Type.CompressedWord as CompressedWord
 import qualified Rattletrap.Type.Replication.Destroyed as Destroyed
 import qualified Rattletrap.Type.Replication.Spawned as Spawned
 import qualified Rattletrap.Type.Replication.Updated as Updated
+import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.Version as Version
 import qualified Rattletrap.Utility.Json as Json
@@ -54,21 +55,22 @@ bitPut value = case value of
   Destroyed x -> BitPut.bool False <> Destroyed.bitPut x
 
 bitGet
-  :: Version.Version
+  :: Maybe Str.Str
+  -> Version.Version
   -> ClassAttributeMap.ClassAttributeMap
   -> CompressedWord.CompressedWord
   -> State.StateT
        (Map.Map CompressedWord.CompressedWord U32.U32)
        BitGet.BitGet
        ReplicationValue
-bitGet version classAttributeMap actorId = do
+bitGet matchType version classAttributeMap actorId = do
   actorMap <- State.get
   isOpen <- Trans.lift BitGet.bool
   if isOpen
     then do
       isNew <- Trans.lift BitGet.bool
       if isNew
-        then fmap Spawned $ Spawned.bitGet version classAttributeMap actorId
+        then fmap Spawned $ Spawned.bitGet matchType version classAttributeMap actorId
         else fmap Updated . Trans.lift $ Updated.bitGet
           version
           classAttributeMap

--- a/src/lib/Rattletrap/Type/Rotation.hs
+++ b/src/lib/Rattletrap/Type/Rotation.hs
@@ -39,10 +39,6 @@ bitPut r = case r of
   Quaternion q -> Quaternion.bitPut q
 
 bitGet :: Version.Version -> BitGet.BitGet Rotation
-bitGet version = if isQuaternion version
+bitGet version = if Version.atLeast 868 22 7 version
   then fmap Quaternion Quaternion.bitGet
   else fmap CompressedWordVector CompressedWordVector.bitGet
-
-isQuaternion :: Version.Version -> Bool
-isQuaternion v =
-  Version.major v >= 868 && Version.minor v >= 22 && Version.patch v >= 7

--- a/src/lib/Rattletrap/Type/Vector.hs
+++ b/src/lib/Rattletrap/Type/Vector.hs
@@ -67,7 +67,7 @@ bitPut vector =
 
 bitGet :: Version.Version -> BitGet.BitGet Vector
 bitGet version = do
-  size <- CompressedWord.bitGet (if has21Bits version then 21 else 19)
+  size <- CompressedWord.bitGet $ if Version.atLeast 868 22 7 version then 21 else 19
   let
     limit = getLimit size
     bias = getBias size
@@ -78,10 +78,6 @@ bitGet version = do
 
 getPart :: Word -> Word -> BitGet.BitGet Int
 getPart limit bias = fmap (fromDelta bias) (CompressedWord.bitGet limit)
-
-has21Bits :: Version.Version -> Bool
-has21Bits v =
-  Version.major v >= 868 && Version.minor v >= 22 && Version.patch v >= 7
 
 getLimit :: CompressedWord.CompressedWord -> Word
 getLimit = (2 ^) . (+ 2) . CompressedWord.value

--- a/src/lib/Rattletrap/Type/Vector.hs
+++ b/src/lib/Rattletrap/Type/Vector.hs
@@ -67,7 +67,8 @@ bitPut vector =
 
 bitGet :: Version.Version -> BitGet.BitGet Vector
 bitGet version = do
-  size <- CompressedWord.bitGet $ if Version.atLeast 868 22 7 version then 21 else 19
+  size <- CompressedWord.bitGet
+    $ if Version.atLeast 868 22 7 version then 21 else 19
   let
     limit = getLimit size
     bias = getBias size

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -5,7 +5,7 @@ import qualified Rattletrap.Type.U32 as U32
 data Version = Version
   { major :: U32.U32
   , minor :: U32.U32
-  , patch :: Int
+  , patch :: Maybe U32.U32
   }
   deriving (Eq, Show)
 
@@ -13,4 +13,4 @@ atLeast :: Int -> Int -> Int -> Version -> Bool
 atLeast m n p v =
   U32.toWord32 (major v) >= fromIntegral m &&
   U32.toWord32 (minor v) >= fromIntegral n &&
-  patch v >= p
+  maybe 0 U32.toWord32 (patch v) >= fromIntegral p

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -1,8 +1,8 @@
 module Rattletrap.Type.Version where
 
-import qualified Rattletrap.Type.U32 as U32
-import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Utility.Monad as Monad
 
 data Version = Version
@@ -14,14 +14,14 @@ data Version = Version
 
 atLeast :: Int -> Int -> Int -> Version -> Bool
 atLeast m n p v =
-  U32.toWord32 (major v) >= fromIntegral m &&
-  U32.toWord32 (minor v) >= fromIntegral n &&
-  maybe 0 U32.toWord32 (patch v) >= fromIntegral p
+  (U32.toWord32 (major v) >= fromIntegral m)
+    && (U32.toWord32 (minor v) >= fromIntegral n)
+    && (maybe 0 U32.toWord32 (patch v) >= fromIntegral p)
 
 bytePut :: Version -> BytePut.BytePut
-bytePut x = U32.bytePut (major x)
-  <> U32.bytePut (minor x)
-  <> foldMap U32.bytePut (patch x)
+bytePut x = U32.bytePut (major x) <> U32.bytePut (minor x) <> foldMap
+  U32.bytePut
+  (patch x)
 
 byteGet :: ByteGet.ByteGet Version
 byteGet = do

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -6,3 +6,6 @@ data Version = Version
   , patch :: Int
   }
   deriving (Eq, Show)
+
+atLeast :: Int -> Int -> Int -> Version -> Bool
+atLeast m n p v = major v >= m && minor v >= n && patch v >= p

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -1,11 +1,16 @@
 module Rattletrap.Type.Version where
 
+import qualified Rattletrap.Type.U32 as U32
+
 data Version = Version
-  { major :: Int
-  , minor :: Int
+  { major :: U32.U32
+  , minor :: U32.U32
   , patch :: Int
   }
   deriving (Eq, Show)
 
 atLeast :: Int -> Int -> Int -> Version -> Bool
-atLeast m n p v = major v >= m && minor v >= n && patch v >= p
+atLeast m n p v =
+  U32.toWord32 (major v) >= fromIntegral m &&
+  U32.toWord32 (minor v) >= fromIntegral n &&
+  patch v >= p

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -1,6 +1,9 @@
 module Rattletrap.Type.Version where
 
 import qualified Rattletrap.Type.U32 as U32
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.Utility.Monad as Monad
 
 data Version = Version
   { major :: U32.U32
@@ -14,3 +17,17 @@ atLeast m n p v =
   U32.toWord32 (major v) >= fromIntegral m &&
   U32.toWord32 (minor v) >= fromIntegral n &&
   maybe 0 U32.toWord32 (patch v) >= fromIntegral p
+
+bytePut :: Version -> BytePut.BytePut
+bytePut x = U32.bytePut (major x)
+  <> U32.bytePut (minor x)
+  <> foldMap U32.bytePut (patch x)
+
+byteGet :: ByteGet.ByteGet Version
+byteGet = do
+  major <- U32.byteGet
+  minor <- U32.byteGet
+  patch <- Monad.whenMaybe
+    (U32.toWord32 major >= 868 && U32.toWord32 minor >= 18)
+    U32.byteGet
+  pure Version { major, minor, patch }


### PR DESCRIPTION
Part of #186. 

I already had a separate `Version` type to use for comparisons, but I wasn't using it for encoding/decoding in the `Header`. This PR fixes that. 