### PR TITLE
Split up property type

### DIFF
--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Byte
     Rattletrap.Type.Property.Float
     Rattletrap.Type.Property.Int
     Rattletrap.Type.Property.Name

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Bool
     Rattletrap.Type.Property.Byte
     Rattletrap.Type.Property.Float
     Rattletrap.Type.Property.Int

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Name
     Rattletrap.Type.Property.QWord
     Rattletrap.Type.Property.Str
     Rattletrap.Type.PropertyValue

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Int
     Rattletrap.Type.Property.Name
     Rattletrap.Type.Property.QWord
     Rattletrap.Type.Property.Str

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.QWord
     Rattletrap.Type.Property.Str
     Rattletrap.Type.PropertyValue
     Rattletrap.Type.Quaternion

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Float
     Rattletrap.Type.Property.Int
     Rattletrap.Type.Property.Name
     Rattletrap.Type.Property.QWord

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Array
     Rattletrap.Type.Property.Bool
     Rattletrap.Type.Property.Byte
     Rattletrap.Type.Property.Float

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -112,6 +112,7 @@ library
     Rattletrap.Type.Mark
     Rattletrap.Type.Message
     Rattletrap.Type.Property
+    Rattletrap.Type.Property.Str
     Rattletrap.Type.PropertyValue
     Rattletrap.Type.Quaternion
     Rattletrap.Type.RemoteId

--- a/src/lib/Rattletrap/Type/Property/Array.hs
+++ b/src/lib/Rattletrap/Type/Property/Array.hs
@@ -24,8 +24,9 @@ instance Json.ToJSON a => Json.ToJSON (Array a) where
   toJSON = Json.toJSON . toList
 
 schema :: Schema.Schema -> Schema.Schema
-schema s = Schema.named "property-array"
-  . Schema.json . List.schema $ Dictionary.schema s
+schema s =
+  Schema.named "property-array" . Schema.json . List.schema $ Dictionary.schema
+    s
 
 bytePut :: (a -> BytePut.BytePut) -> Array a -> BytePut.BytePut
 bytePut f = List.bytePut (Dictionary.bytePut f) . toList

--- a/src/lib/Rattletrap/Type/Property/Array.hs
+++ b/src/lib/Rattletrap/Type/Property/Array.hs
@@ -1,0 +1,34 @@
+module Rattletrap.Type.Property.Array where
+
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Utility.Json as Json
+
+newtype Array a
+  = Array (List.List (Dictionary.Dictionary a))
+  deriving (Eq, Show)
+
+fromList :: List.List (Dictionary.Dictionary a) -> Array a
+fromList = Array
+
+toList :: Array a -> List.List (Dictionary.Dictionary a)
+toList (Array x) = x
+
+instance Json.FromJSON a => Json.FromJSON (Array a) where
+  parseJSON = fmap fromList . Json.parseJSON
+
+instance Json.ToJSON a => Json.ToJSON (Array a) where
+  toJSON = Json.toJSON . toList
+
+schema :: Schema.Schema -> Schema.Schema
+schema s = Schema.named "property-array"
+  . Schema.json . List.schema $ Dictionary.schema s
+
+bytePut :: (a -> BytePut.BytePut) -> Array a -> BytePut.BytePut
+bytePut f = List.bytePut (Dictionary.bytePut f) . toList
+
+byteGet :: ByteGet.ByteGet a -> ByteGet.ByteGet (Array a)
+byteGet f = fmap fromList $ List.byteGet (Dictionary.byteGet f)

--- a/src/lib/Rattletrap/Type/Property/Bool.hs
+++ b/src/lib/Rattletrap/Type/Property/Bool.hs
@@ -1,0 +1,33 @@
+module Rattletrap.Type.Property.Bool where
+
+import Prelude hiding (Bool)
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.U8 as U8
+import qualified Rattletrap.Utility.Json as Json
+
+newtype Bool
+  = Bool U8.U8
+  deriving (Eq, Show)
+
+fromU8 :: U8.U8 -> Bool
+fromU8 = Bool
+
+toU8 :: Bool -> U8.U8
+toU8 (Bool x) = x
+
+instance Json.FromJSON Bool where
+  parseJSON = fmap fromU8 . Json.parseJSON
+
+instance Json.ToJSON Bool where
+  toJSON = Json.toJSON . toU8
+
+schema :: Schema.Schema
+schema = U8.schema
+
+bytePut :: Bool -> BytePut.BytePut
+bytePut = U8.bytePut . toU8
+
+byteGet :: ByteGet.ByteGet Bool
+byteGet = fmap fromU8 U8.byteGet

--- a/src/lib/Rattletrap/Type/Property/Byte.hs
+++ b/src/lib/Rattletrap/Type/Property/Byte.hs
@@ -31,6 +31,7 @@ bytePut byte = Str.bytePut (key byte) <> foldMap Str.bytePut (value byte)
 byteGet :: ByteGet.ByteGet Byte
 byteGet = do
   key <- Str.byteGet
-  value <- Monad.whenMaybe (Str.toString key /= "OnlinePlatform_Steam")
+  value <- Monad.whenMaybe
+    (Str.toString key /= "OnlinePlatform_Steam")
     Str.byteGet
   pure Byte { key, value }

--- a/src/lib/Rattletrap/Type/Property/Byte.hs
+++ b/src/lib/Rattletrap/Type/Property/Byte.hs
@@ -1,0 +1,36 @@
+module Rattletrap.Type.Property.Byte where
+
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.Str as Str
+import qualified Rattletrap.Utility.Json as Json
+import qualified Rattletrap.Utility.Monad as Monad
+
+data Byte = Byte
+  { key :: Str.Str
+  , value :: Maybe Str.Str
+  }
+  deriving (Eq, Show)
+
+instance Json.FromJSON Byte where
+  parseJSON json = do
+    (key, value) <- Json.parseJSON json
+    pure Byte { key, value }
+
+instance Json.ToJSON Byte where
+  toJSON byte = Json.toJSON (key byte, value byte)
+
+schema :: Schema.Schema
+schema = Schema.named "property-byte" $ Schema.tuple
+  [Schema.ref Str.schema, Schema.json $ Schema.maybe Str.schema]
+
+bytePut :: Byte -> BytePut.BytePut
+bytePut byte = Str.bytePut (key byte) <> foldMap Str.bytePut (value byte)
+
+byteGet :: ByteGet.ByteGet Byte
+byteGet = do
+  key <- Str.byteGet
+  value <- Monad.whenMaybe (Str.toString key /= "OnlinePlatform_Steam")
+    Str.byteGet
+  pure Byte { key, value }

--- a/src/lib/Rattletrap/Type/Property/Float.hs
+++ b/src/lib/Rattletrap/Type/Property/Float.hs
@@ -1,0 +1,33 @@
+module Rattletrap.Type.Property.Float where
+
+import Prelude hiding (Float)
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.F32 as F32
+import qualified Rattletrap.Utility.Json as Json
+
+newtype Float
+  = Float F32.F32
+  deriving (Eq, Show)
+
+fromF32 :: F32.F32 -> Float
+fromF32 = Float
+
+toF32 :: Float -> F32.F32
+toF32 (Float x) = x
+
+instance Json.FromJSON Float where
+  parseJSON = fmap fromF32 . Json.parseJSON
+
+instance Json.ToJSON Float where
+  toJSON = Json.toJSON . toF32
+
+schema :: Schema.Schema
+schema = F32.schema
+
+bytePut :: Float -> BytePut.BytePut
+bytePut = F32.bytePut . toF32
+
+byteGet :: ByteGet.ByteGet Float
+byteGet = fmap fromF32 F32.byteGet

--- a/src/lib/Rattletrap/Type/Property/Int.hs
+++ b/src/lib/Rattletrap/Type/Property/Int.hs
@@ -1,0 +1,33 @@
+module Rattletrap.Type.Property.Int where
+
+import Prelude hiding (Int)
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.I32 as I32
+import qualified Rattletrap.Utility.Json as Json
+
+newtype Int
+  = Int I32.I32
+  deriving (Eq, Show)
+
+fromI32 :: I32.I32 -> Int
+fromI32 = Int
+
+toI32 :: Int -> I32.I32
+toI32 (Int x) = x
+
+instance Json.FromJSON Int where
+  parseJSON = fmap fromI32 . Json.parseJSON
+
+instance Json.ToJSON Int where
+  toJSON = Json.toJSON . toI32
+
+schema :: Schema.Schema
+schema = I32.schema
+
+bytePut :: Int -> BytePut.BytePut
+bytePut = I32.bytePut . toI32
+
+byteGet :: ByteGet.ByteGet Int
+byteGet = fmap fromI32 I32.byteGet

--- a/src/lib/Rattletrap/Type/Property/Name.hs
+++ b/src/lib/Rattletrap/Type/Property/Name.hs
@@ -1,0 +1,32 @@
+module Rattletrap.Type.Property.Name where
+
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.Str as Str
+import qualified Rattletrap.Utility.Json as Json
+
+newtype Name
+  = Name Str.Str
+  deriving (Eq, Show)
+
+fromStr :: Str.Str -> Name
+fromStr = Name
+
+toStr :: Name -> Str.Str
+toStr (Name x) = x
+
+instance Json.FromJSON Name where
+  parseJSON = fmap fromStr . Json.parseJSON
+
+instance Json.ToJSON Name where
+  toJSON = Json.toJSON . toStr
+
+schema :: Schema.Schema
+schema = Str.schema
+
+bytePut :: Name -> BytePut.BytePut
+bytePut = Str.bytePut . toStr
+
+byteGet :: ByteGet.ByteGet Name
+byteGet = fmap fromStr Str.byteGet

--- a/src/lib/Rattletrap/Type/Property/QWord.hs
+++ b/src/lib/Rattletrap/Type/Property/QWord.hs
@@ -1,0 +1,32 @@
+module Rattletrap.Type.Property.QWord where
+
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.U64 as U64
+import qualified Rattletrap.Utility.Json as Json
+
+newtype QWord
+  = QWord U64.U64
+  deriving (Eq, Show)
+
+fromU64 :: U64.U64 -> QWord
+fromU64 = QWord
+
+toU64 :: QWord -> U64.U64
+toU64 (QWord x) = x
+
+instance Json.FromJSON QWord where
+  parseJSON = fmap fromU64 . Json.parseJSON
+
+instance Json.ToJSON QWord where
+  toJSON = Json.toJSON . toU64
+
+schema :: Schema.Schema
+schema = U64.schema
+
+bytePut :: QWord -> BytePut.BytePut
+bytePut = U64.bytePut . toU64
+
+byteGet :: ByteGet.ByteGet QWord
+byteGet = fmap fromU64 U64.byteGet

--- a/src/lib/Rattletrap/Type/Property/Str.hs
+++ b/src/lib/Rattletrap/Type/Property/Str.hs
@@ -1,0 +1,32 @@
+module Rattletrap.Type.Property.Str where
+
+import qualified Rattletrap.ByteGet as ByteGet
+import qualified Rattletrap.BytePut as BytePut
+import qualified Rattletrap.Schema as Schema
+import qualified Rattletrap.Type.Str as Str
+import qualified Rattletrap.Utility.Json as Json
+
+newtype Str
+  = Str Str.Str
+  deriving (Eq, Show)
+
+fromStr :: Str.Str -> Str
+fromStr = Str
+
+toStr :: Str -> Str.Str
+toStr (Str x) = x
+
+instance Json.FromJSON Str where
+  parseJSON = fmap fromStr . Json.parseJSON
+
+instance Json.ToJSON Str where
+  toJSON = Json.toJSON . toStr
+
+schema :: Schema.Schema
+schema = Str.schema
+
+bytePut :: Str -> BytePut.BytePut
+bytePut = Str.bytePut . toStr
+
+byteGet :: ByteGet.ByteGet Str
+byteGet = fmap fromStr Str.byteGet

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -6,11 +6,11 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.Property.Int as Property.Int
 import qualified Rattletrap.Type.Property.Name as Property.Name
 import qualified Rattletrap.Type.Property.QWord as Property.QWord
 import qualified Rattletrap.Type.Property.Str as Property.Str
 import qualified Rattletrap.Type.F32 as F32
-import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U8 as U8
@@ -25,7 +25,7 @@ data PropertyValue a
   | Byte Str.Str (Maybe Str.Str)
   -- ^ This is a strange name for essentially a key-value pair.
   | Float F32.F32
-  | Int I32.I32
+  | Int Property.Int.Int
   | Name Property.Name.Name
   -- ^ It's unclear how exactly this is different than a 'StrProperty'.
   | QWord Property.QWord.QWord
@@ -68,7 +68,7 @@ schema s =
             [Schema.ref Str.schema, Schema.json $ Schema.maybe Str.schema]
           )
         , ("float", Schema.ref F32.schema)
-        , ("int", Schema.ref I32.schema)
+        , ("int", Schema.ref Property.Int.schema)
         , ("name", Schema.ref Property.Name.schema)
         , ("q_word", Schema.ref Property.QWord.schema)
         , ("str", Schema.ref Property.Str.schema)
@@ -80,7 +80,7 @@ bytePut putProperty value = case value of
   Bool x -> U8.bytePut x
   Byte k mv -> Str.bytePut k <> foldMap Str.bytePut mv
   Float x -> F32.bytePut x
-  Int x -> I32.bytePut x
+  Int x -> Property.Int.bytePut x
   Name x -> Property.Name.bytePut x
   QWord x -> Property.QWord.bytePut x
   Str x -> Property.Str.bytePut x
@@ -95,7 +95,7 @@ byteGet getProperty kind = case Str.toString kind of
     v <- whenMaybe (Str.toString k /= "OnlinePlatform_Steam") Str.byteGet
     pure $ Byte k v
   "FloatProperty" -> fmap Float F32.byteGet
-  "IntProperty" -> fmap Int I32.byteGet
+  "IntProperty" -> fmap Int Property.Int.byteGet
   "NameProperty" -> fmap Name Property.Name.byteGet
   "QWordProperty" -> fmap QWord Property.QWord.byteGet
   "StrProperty" -> fmap Str Property.Str.byteGet

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -6,6 +6,7 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.Property.Bool as Property.Bool
 import qualified Rattletrap.Type.Property.Byte as Property.Byte
 import qualified Rattletrap.Type.Property.Float as Property.Float
 import qualified Rattletrap.Type.Property.Int as Property.Int
@@ -14,14 +15,13 @@ import qualified Rattletrap.Type.Property.QWord as Property.QWord
 import qualified Rattletrap.Type.Property.Str as Property.Str
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Str as Str
-import qualified Rattletrap.Type.U8 as U8
 import qualified Rattletrap.Utility.Json as Json
 
 data PropertyValue a
   = Array (List.List (Dictionary.Dictionary a))
   -- ^ Yes, a list of dictionaries. No, it doesn't make sense. These usually
   -- only have one element.
-  | Bool U8.U8
+  | Bool Property.Bool.Bool
   | Byte Property.Byte.Byte
   -- ^ This is a strange name for essentially a key-value pair.
   | Float Property.Float.Float
@@ -62,7 +62,7 @@ schema s =
     $ fmap
         (\(k, v) -> Schema.object [(Json.pair k v, True)])
         [ ("array", Schema.json . List.schema $ Dictionary.schema s)
-        , ("bool", Schema.ref U8.schema)
+        , ("bool", Schema.ref Property.Bool.schema)
         , ("byte", Schema.ref Property.Byte.schema)
         , ("float", Schema.ref Property.Float.schema)
         , ("int", Schema.ref Property.Int.schema)
@@ -74,7 +74,7 @@ schema s =
 bytePut :: (a -> BytePut.BytePut) -> PropertyValue a -> BytePut.BytePut
 bytePut putProperty value = case value of
   Array x -> List.bytePut (Dictionary.bytePut putProperty) x
-  Bool x -> U8.bytePut x
+  Bool x -> Property.Bool.bytePut x
   Byte x -> Property.Byte.bytePut x
   Float x -> Property.Float.bytePut x
   Int x -> Property.Int.bytePut x
@@ -86,7 +86,7 @@ byteGet :: ByteGet.ByteGet a -> Str.Str -> ByteGet.ByteGet (PropertyValue a)
 byteGet getProperty kind = case Str.toString kind of
   "ArrayProperty" ->
     fmap Array $ List.byteGet (Dictionary.byteGet getProperty)
-  "BoolProperty" -> fmap Bool U8.byteGet
+  "BoolProperty" -> fmap Bool Property.Bool.byteGet
   "ByteProperty" -> fmap Byte Property.Byte.byteGet
   "FloatProperty" -> fmap Float Property.Float.byteGet
   "IntProperty" -> fmap Int Property.Int.byteGet

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -6,11 +6,11 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.Property.Float as Property.Float
 import qualified Rattletrap.Type.Property.Int as Property.Int
 import qualified Rattletrap.Type.Property.Name as Property.Name
 import qualified Rattletrap.Type.Property.QWord as Property.QWord
 import qualified Rattletrap.Type.Property.Str as Property.Str
-import qualified Rattletrap.Type.F32 as F32
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U8 as U8
@@ -24,7 +24,7 @@ data PropertyValue a
   | Bool U8.U8
   | Byte Str.Str (Maybe Str.Str)
   -- ^ This is a strange name for essentially a key-value pair.
-  | Float F32.F32
+  | Float Property.Float.Float
   | Int Property.Int.Int
   | Name Property.Name.Name
   -- ^ It's unclear how exactly this is different than a 'StrProperty'.
@@ -67,7 +67,7 @@ schema s =
           , Schema.tuple
             [Schema.ref Str.schema, Schema.json $ Schema.maybe Str.schema]
           )
-        , ("float", Schema.ref F32.schema)
+        , ("float", Schema.ref Property.Float.schema)
         , ("int", Schema.ref Property.Int.schema)
         , ("name", Schema.ref Property.Name.schema)
         , ("q_word", Schema.ref Property.QWord.schema)
@@ -79,7 +79,7 @@ bytePut putProperty value = case value of
   Array x -> List.bytePut (Dictionary.bytePut putProperty) x
   Bool x -> U8.bytePut x
   Byte k mv -> Str.bytePut k <> foldMap Str.bytePut mv
-  Float x -> F32.bytePut x
+  Float x -> Property.Float.bytePut x
   Int x -> Property.Int.bytePut x
   Name x -> Property.Name.bytePut x
   QWord x -> Property.QWord.bytePut x
@@ -94,7 +94,7 @@ byteGet getProperty kind = case Str.toString kind of
     k <- Str.byteGet
     v <- whenMaybe (Str.toString k /= "OnlinePlatform_Steam") Str.byteGet
     pure $ Byte k v
-  "FloatProperty" -> fmap Float F32.byteGet
+  "FloatProperty" -> fmap Float Property.Float.byteGet
   "IntProperty" -> fmap Int Property.Int.byteGet
   "NameProperty" -> fmap Name Property.Name.byteGet
   "QWordProperty" -> fmap QWord Property.QWord.byteGet

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -6,12 +6,12 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.Property.QWord as Property.QWord
 import qualified Rattletrap.Type.Property.Str as Property.Str
 import qualified Rattletrap.Type.F32 as F32
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.List as List
 import qualified Rattletrap.Type.Str as Str
-import qualified Rattletrap.Type.U64 as U64
 import qualified Rattletrap.Type.U8 as U8
 import qualified Rattletrap.Utility.Json as Json
 import Rattletrap.Utility.Monad
@@ -27,7 +27,7 @@ data PropertyValue a
   | Int I32.I32
   | Name Str.Str
   -- ^ It's unclear how exactly this is different than a 'StrProperty'.
-  | QWord U64.U64
+  | QWord Property.QWord.QWord
   | Str Property.Str.Str
   deriving (Eq, Show)
 
@@ -69,7 +69,7 @@ schema s =
         , ("float", Schema.ref F32.schema)
         , ("int", Schema.ref I32.schema)
         , ("name", Schema.ref Str.schema)
-        , ("q_word", Schema.ref U64.schema)
+        , ("q_word", Schema.ref Property.QWord.schema)
         , ("str", Schema.ref Property.Str.schema)
         ]
 
@@ -81,7 +81,7 @@ bytePut putProperty value = case value of
   Float x -> F32.bytePut x
   Int x -> I32.bytePut x
   Name x -> Str.bytePut x
-  QWord x -> U64.bytePut x
+  QWord x -> Property.QWord.bytePut x
   Str x -> Property.Str.bytePut x
 
 byteGet :: ByteGet.ByteGet a -> Str.Str -> ByteGet.ByteGet (PropertyValue a)
@@ -96,6 +96,6 @@ byteGet getProperty kind = case Str.toString kind of
   "FloatProperty" -> fmap Float F32.byteGet
   "IntProperty" -> fmap Int I32.byteGet
   "NameProperty" -> fmap Name Str.byteGet
-  "QWordProperty" -> fmap QWord U64.byteGet
+  "QWordProperty" -> fmap QWord Property.QWord.byteGet
   "StrProperty" -> fmap Str Property.Str.byteGet
   _ -> fail ("[RT07] don't know how to read property value " <> show kind)

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -6,6 +6,7 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.Property.Str as Property.Str
 import qualified Rattletrap.Type.F32 as F32
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.List as List
@@ -27,7 +28,7 @@ data PropertyValue a
   | Name Str.Str
   -- ^ It's unclear how exactly this is different than a 'StrProperty'.
   | QWord U64.U64
-  | Str Str.Str
+  | Str Property.Str.Str
   deriving (Eq, Show)
 
 instance Json.FromJSON a => Json.FromJSON (PropertyValue a) where
@@ -69,7 +70,7 @@ schema s =
         , ("int", Schema.ref I32.schema)
         , ("name", Schema.ref Str.schema)
         , ("q_word", Schema.ref U64.schema)
-        , ("str", Schema.ref Str.schema)
+        , ("str", Schema.ref Property.Str.schema)
         ]
 
 bytePut :: (a -> BytePut.BytePut) -> PropertyValue a -> BytePut.BytePut
@@ -81,7 +82,7 @@ bytePut putProperty value = case value of
   Int x -> I32.bytePut x
   Name x -> Str.bytePut x
   QWord x -> U64.bytePut x
-  Str x -> Str.bytePut x
+  Str x -> Property.Str.bytePut x
 
 byteGet :: ByteGet.ByteGet a -> Str.Str -> ByteGet.ByteGet (PropertyValue a)
 byteGet getProperty kind = case Str.toString kind of
@@ -96,5 +97,5 @@ byteGet getProperty kind = case Str.toString kind of
   "IntProperty" -> fmap Int I32.byteGet
   "NameProperty" -> fmap Name Str.byteGet
   "QWordProperty" -> fmap QWord U64.byteGet
-  "StrProperty" -> fmap Str Str.byteGet
+  "StrProperty" -> fmap Str Property.Str.byteGet
   _ -> fail ("[RT07] don't know how to read property value " <> show kind)

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -6,6 +6,7 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
+import qualified Rattletrap.Type.Property.Name as Property.Name
 import qualified Rattletrap.Type.Property.QWord as Property.QWord
 import qualified Rattletrap.Type.Property.Str as Property.Str
 import qualified Rattletrap.Type.F32 as F32
@@ -25,7 +26,7 @@ data PropertyValue a
   -- ^ This is a strange name for essentially a key-value pair.
   | Float F32.F32
   | Int I32.I32
-  | Name Str.Str
+  | Name Property.Name.Name
   -- ^ It's unclear how exactly this is different than a 'StrProperty'.
   | QWord Property.QWord.QWord
   | Str Property.Str.Str
@@ -68,7 +69,7 @@ schema s =
           )
         , ("float", Schema.ref F32.schema)
         , ("int", Schema.ref I32.schema)
-        , ("name", Schema.ref Str.schema)
+        , ("name", Schema.ref Property.Name.schema)
         , ("q_word", Schema.ref Property.QWord.schema)
         , ("str", Schema.ref Property.Str.schema)
         ]
@@ -80,7 +81,7 @@ bytePut putProperty value = case value of
   Byte k mv -> Str.bytePut k <> foldMap Str.bytePut mv
   Float x -> F32.bytePut x
   Int x -> I32.bytePut x
-  Name x -> Str.bytePut x
+  Name x -> Property.Name.bytePut x
   QWord x -> Property.QWord.bytePut x
   Str x -> Property.Str.bytePut x
 
@@ -95,7 +96,7 @@ byteGet getProperty kind = case Str.toString kind of
     pure $ Byte k v
   "FloatProperty" -> fmap Float F32.byteGet
   "IntProperty" -> fmap Int I32.byteGet
-  "NameProperty" -> fmap Name Str.byteGet
+  "NameProperty" -> fmap Name Property.Name.byteGet
   "QWordProperty" -> fmap QWord Property.QWord.byteGet
   "StrProperty" -> fmap Str Property.Str.byteGet
   _ -> fail ("[RT07] don't know how to read property value " <> show kind)

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -54,20 +54,17 @@ instance Json.ToJSON a => Json.ToJSON (PropertyValue a) where
     Str y -> Json.object [Json.pair "str" y]
 
 schema :: Schema.Schema -> Schema.Schema
-schema s =
-  Schema.named "property-value"
-    . Schema.oneOf
-    $ fmap
-        (\(k, v) -> Schema.object [(Json.pair k v, True)])
-        [ ("array", Schema.ref $ Property.Array.schema s)
-        , ("bool", Schema.ref Property.Bool.schema)
-        , ("byte", Schema.ref Property.Byte.schema)
-        , ("float", Schema.ref Property.Float.schema)
-        , ("int", Schema.ref Property.Int.schema)
-        , ("name", Schema.ref Property.Name.schema)
-        , ("q_word", Schema.ref Property.QWord.schema)
-        , ("str", Schema.ref Property.Str.schema)
-        ]
+schema s = Schema.named "property-value" . Schema.oneOf $ fmap
+  (\(k, v) -> Schema.object [(Json.pair k v, True)])
+  [ ("array", Schema.ref $ Property.Array.schema s)
+  , ("bool", Schema.ref Property.Bool.schema)
+  , ("byte", Schema.ref Property.Byte.schema)
+  , ("float", Schema.ref Property.Float.schema)
+  , ("int", Schema.ref Property.Int.schema)
+  , ("name", Schema.ref Property.Name.schema)
+  , ("q_word", Schema.ref Property.QWord.schema)
+  , ("str", Schema.ref Property.Str.schema)
+  ]
 
 bytePut :: (a -> BytePut.BytePut) -> PropertyValue a -> BytePut.BytePut
 bytePut putProperty value = case value of

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -8,6 +8,7 @@ import qualified Rattletrap.Type.Dictionary as Dictionary
 import qualified Rattletrap.Type.Header as Header
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.Property as Property
+import qualified Rattletrap.Type.Property.Int as Property.Int
 import qualified Rattletrap.Type.Property.Name as Property.Name
 import qualified Rattletrap.Type.PropertyValue as PropertyValue
 import qualified Rattletrap.Type.Section as Section
@@ -110,7 +111,7 @@ getNumFrames header_ =
         (Header.properties header_)
     of
       Just (Property.Property _ _ (PropertyValue.Int numFrames)) ->
-        fromIntegral (I32.toInt32 numFrames)
+        fromIntegral (I32.toInt32 (Property.Int.toI32 numFrames))
       _ -> 0
 
 getMaxChannels :: Header.Header -> Word
@@ -120,6 +121,6 @@ getMaxChannels header_ =
         (Str.fromString "MaxChannels")
         (Header.properties header_)
     of
-      Just (Property.Property _ _ (PropertyValue.Int numFrames)) ->
-        fromIntegral (I32.toInt32 numFrames)
+      Just (Property.Property _ _ (PropertyValue.Int maxChannels)) ->
+        fromIntegral (I32.toInt32 (Property.Int.toI32 maxChannels))
       _ -> 1023

--- a/src/lib/Rattletrap/Type/Replay.hs
+++ b/src/lib/Rattletrap/Type/Replay.hs
@@ -8,6 +8,7 @@ import qualified Rattletrap.Type.Dictionary as Dictionary
 import qualified Rattletrap.Type.Header as Header
 import qualified Rattletrap.Type.I32 as I32
 import qualified Rattletrap.Type.Property as Property
+import qualified Rattletrap.Type.Property.Name as Property.Name
 import qualified Rattletrap.Type.PropertyValue as PropertyValue
 import qualified Rattletrap.Type.Section as Section
 import qualified Rattletrap.Type.Str as Str
@@ -97,8 +98,8 @@ getPatchVersion header_ = case Header.patchVersion header_ of
       of
       -- This is an ugly, ugly hack to handle replays from season 2 of RLCS.
       -- See `decodeSpawnedReplicationBits` and #85.
-        Just Property.Property { Property.value = PropertyValue.Name str }
-          | Str.toString str == "Lan" -> -1
+        Just Property.Property { Property.value = PropertyValue.Name name }
+          | Str.toString (Property.Name.toStr name) == "Lan" -> -1
         _ -> 0
 
 getNumFrames :: Header.Header -> Int


### PR DESCRIPTION
Part of #186. 

This PR splits up the `PropertyValue` type so that each constructor simply wraps another type. For most types this is pure overhead: `Property.Str` is just a wrapper around `Str`. For other types this is actually useful: `Property.Byte` manages a fair amount of complexity. 