### PR TITLE
Stop reversing bytes, and stop using binary and binary-bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.ps
 *.tix
 /dist-newstyle/
+/.vscode/

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -23,9 +23,7 @@ library
     , aeson >= 1.5.5 && < 1.6
     , aeson-pretty >= 0.8.8 && < 0.9
     , array >= 0.5.4 && < 0.6
-    , binary >= 0.8.8 && < 0.9
     , bytestring >= 0.10.12 && < 0.11
-    , caerbannog >= 0.6.0 && < 0.7
     , containers >= 0.6.2 && < 0.7
     , filepath >= 1.4.2 && < 1.5
     , http-client >= 0.6.4 && < 0.8

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -39,6 +39,7 @@ library
     Rattletrap
     Rattletrap.BitGet
     Rattletrap.BitPut
+    Rattletrap.BitString
     Rattletrap.ByteGet
     Rattletrap.BytePut
     Rattletrap.Console.Config

--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -37,6 +37,7 @@ library
   exposed-modules:
     Paths_rattletrap
     Rattletrap
+    Rattletrap.BitBuilder
     Rattletrap.BitGet
     Rattletrap.BitPut
     Rattletrap.BitString

--- a/src/lib/Rattletrap/BitBuilder.hs
+++ b/src/lib/Rattletrap/BitBuilder.hs
@@ -1,0 +1,30 @@
+module Rattletrap.BitBuilder where
+
+import qualified Data.Bits as Bits
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.Word as Word
+
+data BitBuilder = BitBuilder
+  { buffer :: Word.Word8
+  , builder :: Builder.Builder
+  , offset :: Int
+  }
+
+empty :: BitBuilder
+empty = BitBuilder { buffer = 0x00, builder = mempty, offset = 0 }
+
+push :: Bool -> BitBuilder -> BitBuilder
+push b x =
+  let newBuffer = if b then Bits.setBit (buffer x) (offset x) else buffer x
+  in
+    if offset x == 7
+      then BitBuilder
+        { buffer = 0x00
+        , builder = builder x <> Builder.word8 newBuffer
+        , offset = 0
+        }
+      else x { buffer = newBuffer, offset = offset x + 1 }
+
+toBuilder :: BitBuilder -> Builder.Builder
+toBuilder x =
+  if offset x == 0 then builder x else builder x <> Builder.word8 (buffer x)

--- a/src/lib/Rattletrap/BitBuilder.hs
+++ b/src/lib/Rattletrap/BitBuilder.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Rattletrap.BitBuilder where
 
 import qualified Data.Bits as Bits
@@ -15,7 +17,7 @@ empty = BitBuilder { buffer = 0x00, builder = mempty, offset = 0 }
 
 push :: Bool -> BitBuilder -> BitBuilder
 push b x =
-  let newBuffer = if b then Bits.setBit (buffer x) (offset x) else buffer x
+  let !newBuffer = if b then Bits.setBit (buffer x) (offset x) else buffer x
   in
     if offset x == 7
       then BitBuilder

--- a/src/lib/Rattletrap/BitBuilder.hs
+++ b/src/lib/Rattletrap/BitBuilder.hs
@@ -1,3 +1,4 @@
+{- hlint ignore "Avoid restricted extensions" -}
 {-# LANGUAGE BangPatterns #-}
 
 module Rattletrap.BitBuilder where

--- a/src/lib/Rattletrap/BitPut.hs
+++ b/src/lib/Rattletrap/BitPut.hs
@@ -4,7 +4,6 @@ import qualified Data.Binary.Bits.Put as BinaryBits
 import qualified Data.Binary.Put as Binary
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as ByteString
-import qualified Data.Word as Word
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Utility.Bytes as Utility
 
@@ -36,6 +35,3 @@ bool = fromBinaryBits . BinaryBits.putBool
 
 byteString :: ByteString.ByteString -> BitPut
 byteString = fromBinaryBits . BinaryBits.putByteString
-
-word8 :: Int -> Word.Word8 -> BitPut
-word8 n = fromBinaryBits . BinaryBits.putWord8 n

--- a/src/lib/Rattletrap/BitPut.hs
+++ b/src/lib/Rattletrap/BitPut.hs
@@ -1,37 +1,32 @@
 module Rattletrap.BitPut where
 
-import qualified Data.Binary.Bits.Put as BinaryBits
-import qualified Data.Binary.Put as Binary
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as ByteString
+import qualified Rattletrap.BitBuilder as BitBuilder
 import qualified Rattletrap.BytePut as BytePut
-import qualified Rattletrap.Utility.Bytes as Utility
 
-newtype BitPut = BitPut (BinaryBits.BitPut ())
+newtype BitPut = BitPut (BitBuilder.BitBuilder -> BitBuilder.BitBuilder)
 
 instance Semigroup BitPut where
-  x <> y = fromBinaryBits $ toBinaryBits x >> toBinaryBits y
+  f1 <> f2 = BitPut $ run f2 . run f1
 
 instance Monoid BitPut where
-  mempty = fromBinaryBits $ pure ()
+  mempty = BitPut id
 
-fromBinaryBits :: BinaryBits.BitPut () -> BitPut
-fromBinaryBits = BitPut
-
-toBinaryBits :: BitPut -> BinaryBits.BitPut ()
-toBinaryBits (BitPut x) = x
+run :: BitPut -> BitBuilder.BitBuilder -> BitBuilder.BitBuilder
+run (BitPut f) = f
 
 toBytePut :: BitPut -> BytePut.BytePut
-toBytePut = Binary.execPut . BinaryBits.runBitPut . toBinaryBits
+toBytePut b = BitBuilder.toBuilder $ run b BitBuilder.empty
 
 fromBytePut :: BytePut.BytePut -> BitPut
-fromBytePut = byteString . Utility.reverseBytes . BytePut.toByteString
+fromBytePut = byteString . BytePut.toByteString
 
 bits :: Bits.Bits a => Int -> a -> BitPut
 bits n x = foldMap (bool . Bits.testBit x) [0 .. n - 1]
 
 bool :: Bool -> BitPut
-bool = fromBinaryBits . BinaryBits.putBool
+bool = BitPut . BitBuilder.push
 
 byteString :: ByteString.ByteString -> BitPut
-byteString = fromBinaryBits . BinaryBits.putByteString
+byteString = foldMap (bits 8) . ByteString.unpack

--- a/src/lib/Rattletrap/BitString.hs
+++ b/src/lib/Rattletrap/BitString.hs
@@ -1,0 +1,23 @@
+module Rattletrap.BitString where
+
+import qualified Data.Bits as Bits
+import qualified Data.ByteString as ByteString
+
+data BitString = BitString
+  { byteString :: ByteString.ByteString
+  , offset :: Int
+  }
+  deriving (Eq, Show)
+
+fromByteString :: ByteString.ByteString -> BitString
+fromByteString byteString = BitString { byteString, offset = 0 }
+
+pop :: BitString -> Maybe (Bool, BitString)
+pop old = do
+  (word, byteString) <- ByteString.uncons $ byteString old
+  let
+    bit = Bits.testBit word $ offset old
+    new = if offset old == 7
+      then fromByteString byteString
+      else old { offset = offset old + 1 }
+  pure (bit, new)

--- a/src/lib/Rattletrap/Type/Attribute/GameMode.hs
+++ b/src/lib/Rattletrap/Type/Attribute/GameMode.hs
@@ -40,5 +40,5 @@ bitPut gameModeAttribute = do
 bitGet :: Version.Version -> BitGet.BitGet GameMode
 bitGet version = do
   let numBits = if Version.atLeast 868 12 0 version then 8 else 2 :: Int
-  word <- BitGet.word8 numBits
+  word <- BitGet.bits numBits
   pure GameMode { numBits, word }

--- a/src/lib/Rattletrap/Type/Attribute/GameMode.hs
+++ b/src/lib/Rattletrap/Type/Attribute/GameMode.hs
@@ -35,7 +35,7 @@ schema = Schema.named "attribute-game-mode" $ Schema.object
 
 bitPut :: GameMode -> BitPut.BitPut
 bitPut gameModeAttribute = do
-  BitPut.word8 (numBits gameModeAttribute) (word gameModeAttribute)
+  BitPut.bits (numBits gameModeAttribute) (word gameModeAttribute)
 
 bitGet :: Version.Version -> BitGet.BitGet GameMode
 bitGet version = do

--- a/src/lib/Rattletrap/Type/Attribute/Reservation.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Reservation.hs
@@ -59,7 +59,7 @@ bitPut reservationAttribute =
     <> foldMap Str.bitPut (name reservationAttribute)
     <> BitPut.bool (unknown1 reservationAttribute)
     <> BitPut.bool (unknown2 reservationAttribute)
-    <> foldMap (BitPut.word8 6) (unknown3 reservationAttribute)
+    <> foldMap (BitPut.bits 6) (unknown3 reservationAttribute)
 
 bitGet :: Version.Version -> BitGet.BitGet Reservation
 bitGet version = do

--- a/src/lib/Rattletrap/Type/Attribute/Reservation.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Reservation.hs
@@ -68,5 +68,5 @@ bitGet version = do
   name <- whenMaybe (UniqueId.systemId uniqueId /= U8.fromWord8 0) Str.bitGet
   unknown1 <- BitGet.bool
   unknown2 <- BitGet.bool
-  unknown3 <- whenMaybe (Version.atLeast 868 12 0 version) $ BitGet.word8 6
+  unknown3 <- whenMaybe (Version.atLeast 868 12 0 version) $ BitGet.bits 6
   pure Reservation { number, uniqueId, name, unknown1, unknown2, unknown3 }

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -214,9 +214,7 @@ byteGet matchType version numFrames maxChannels = do
         classAttributeMap
       )
       mempty
-  frames <-
-    either fail pure . ByteGet.run (BitGet.toByteGet bitGet) $ reverseBytes
-      stream
+  frames <- either fail pure $ ByteGet.run (BitGet.toByteGet bitGet) stream
   unknown <- fmap LazyBytes.unpack ByteGet.remaining
   pure Content
     { levels

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -176,8 +176,8 @@ putFrames x =
     actualStreamSize = U32.fromWord32 . fromIntegral $ Bytes.length stream
     streamSize_ = U32.fromWord32
       $ max (U32.toWord32 expectedStreamSize) (U32.toWord32 actualStreamSize)
-  in U32.bytePut streamSize_ <> BytePut.byteString
-    (reverseBytes (padBytes (U32.toWord32 streamSize_) stream))
+  in U32.bytePut streamSize_
+    <> BytePut.byteString (padBytes (U32.toWord32 streamSize_) stream)
 
 byteGet
   :: Maybe Str.Str

--- a/src/lib/Rattletrap/Type/RemoteId/PlayStation.hs
+++ b/src/lib/Rattletrap/Type/RemoteId/PlayStation.hs
@@ -32,11 +32,7 @@ schema = Schema.named "remote-id-play-station" $ Schema.tuple
 bitPut :: PlayStation -> BitPut.BitPut
 bitPut x =
   let
-    nameBytes =
-      Bytes.reverseBytes
-        . Bytes.padBytes (16 :: Int)
-        . Bytes.encodeLatin1
-        $ name x
+    nameBytes = Bytes.padBytes (16 :: Int) . Bytes.encodeLatin1 $ name x
     codeBytes = ByteString.pack $ code x
   in BitPut.byteString nameBytes <> BitPut.byteString codeBytes
 

--- a/src/lib/Rattletrap/Type/RemoteId/PlayStation.hs
+++ b/src/lib/Rattletrap/Type/RemoteId/PlayStation.hs
@@ -48,7 +48,7 @@ bitGet version = do
 
 getCode :: BitGet.BitGet Text.Text
 getCode =
-  fmap (Text.dropWhileEnd (== '\x00') . Text.decodeLatin1 . Bytes.reverseBytes)
+  fmap (Text.dropWhileEnd (== '\x00') . Text.decodeLatin1)
     $ BitGet.byteString 16
 
 getName :: Version.Version -> BitGet.BitGet [Word.Word8]

--- a/src/lib/Rattletrap/Type/RemoteId/PlayStation.hs
+++ b/src/lib/Rattletrap/Type/RemoteId/PlayStation.hs
@@ -47,9 +47,8 @@ bitGet version = do
   pure PlayStation { name, code }
 
 getCode :: BitGet.BitGet Text.Text
-getCode =
-  fmap (Text.dropWhileEnd (== '\x00') . Text.decodeLatin1)
-    $ BitGet.byteString 16
+getCode = fmap (Text.dropWhileEnd (== '\x00') . Text.decodeLatin1)
+  $ BitGet.byteString 16
 
 getName :: Version.Version -> BitGet.BitGet [Word.Word8]
 getName version =

--- a/src/lib/Rattletrap/Type/Str.hs
+++ b/src/lib/Rattletrap/Type/Str.hs
@@ -82,7 +82,7 @@ bitGet :: BitGet.BitGet Str
 bitGet = do
   rawSize <- I32.bitGet
   bytes <- BitGet.byteString (normalizeTextSize rawSize)
-  pure (fromText (dropNull (getTextDecoder rawSize (reverseBytes bytes))))
+  pure (fromText (dropNull (getTextDecoder rawSize bytes)))
 
 normalizeTextSize :: Integral a => I32.I32 -> a
 normalizeTextSize size = case I32.toInt32 size of

--- a/src/lib/Rattletrap/Utility/Bytes.hs
+++ b/src/lib/Rattletrap/Utility/Bytes.hs
@@ -1,14 +1,11 @@
 module Rattletrap.Utility.Bytes
   ( encodeLatin1
   , padBytes
-  , reverseBytes
   ) where
 
-import qualified Data.Bits as Bits
 import qualified Data.ByteString as Bytes
 import qualified Data.ByteString.Char8 as Bytes8
 import qualified Data.Text as Text
-import qualified Data.Word as Word
 
 encodeLatin1 :: Text.Text -> Bytes.ByteString
 encodeLatin1 text = Bytes8.pack (Text.unpack text)
@@ -16,17 +13,3 @@ encodeLatin1 text = Bytes8.pack (Text.unpack text)
 padBytes :: Integral a => a -> Bytes.ByteString -> Bytes.ByteString
 padBytes size bytes =
   bytes <> Bytes.replicate (fromIntegral size - Bytes.length bytes) 0x00
-
-reverseByte :: Word.Word8 -> Word.Word8
-reverseByte byte =
-  Bits.shiftR (byte Bits..&. Bits.bit 7) 7
-    + Bits.shiftR (byte Bits..&. Bits.bit 6) 5
-    + Bits.shiftR (byte Bits..&. Bits.bit 5) 3
-    + Bits.shiftR (byte Bits..&. Bits.bit 4) 1
-    + Bits.shiftL (byte Bits..&. Bits.bit 3) 1
-    + Bits.shiftL (byte Bits..&. Bits.bit 2) 3
-    + Bits.shiftL (byte Bits..&. Bits.bit 1) 5
-    + Bits.shiftL (byte Bits..&. Bits.bit 0) 7
-
-reverseBytes :: Bytes.ByteString -> Bytes.ByteString
-reverseBytes = Bytes.map reverseByte

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,3 @@
 resolver: lts-17.0
 extra-deps:
-  - caerbannog-0.6.0.4
   - data-tree-print-0.1.0.2


### PR DESCRIPTION
This will fix #188. It will also fix #189. 

Currently I expect the build to fail. The replays generated with `BitPut` don't match what's parsed with `BitGet`. I suspect that discrepancy will go away once I migrate `BitPut` away from `binary-bits` and `reverseBytes`. 

However it does mean that some values are changing. I think that's expected -- they were wrong in the first place. But I should diff the pretty replay JSON between `main` and this branch to see what exactly changed. 