### PR TITLE
Add labels

### DIFF
--- a/src/lib/Rattletrap/Type/AttributeMapping.hs
+++ b/src/lib/Rattletrap/Type/AttributeMapping.hs
@@ -32,7 +32,7 @@ bytePut :: AttributeMapping -> BytePut.BytePut
 bytePut x = U32.bytePut (objectId x) <> U32.bytePut (streamId x)
 
 byteGet :: ByteGet.ByteGet AttributeMapping
-byteGet = do
-  objectId <- U32.byteGet
-  streamId <- U32.byteGet
+byteGet = ByteGet.label "AttributeMapping" $ do
+  objectId <- ByteGet.label "objectId" U32.byteGet
+  streamId <- ByteGet.label "streamId" U32.byteGet
   pure AttributeMapping { objectId, streamId }

--- a/src/lib/Rattletrap/Type/Cache.hs
+++ b/src/lib/Rattletrap/Type/Cache.hs
@@ -51,9 +51,9 @@ bytePut x =
     <> List.bytePut AttributeMapping.bytePut (attributeMappings x)
 
 byteGet :: ByteGet.ByteGet Cache
-byteGet = do
-  classId <- U32.byteGet
-  parentCacheId <- U32.byteGet
-  cacheId <- U32.byteGet
-  attributeMappings <- List.byteGet AttributeMapping.byteGet
+byteGet = ByteGet.label "Cache" $ do
+  classId <- ByteGet.label "classId" U32.byteGet
+  parentCacheId <- ByteGet.label "parentCacheId" U32.byteGet
+  cacheId <- ByteGet.label "cacheId" U32.byteGet
+  attributeMappings <- ByteGet.label "attributeMappings" $ List.byteGet AttributeMapping.byteGet
   pure Cache { classId, parentCacheId, cacheId, attributeMappings }

--- a/src/lib/Rattletrap/Type/Cache.hs
+++ b/src/lib/Rattletrap/Type/Cache.hs
@@ -55,5 +55,6 @@ byteGet = ByteGet.label "Cache" $ do
   classId <- ByteGet.label "classId" U32.byteGet
   parentCacheId <- ByteGet.label "parentCacheId" U32.byteGet
   cacheId <- ByteGet.label "cacheId" U32.byteGet
-  attributeMappings <- ByteGet.label "attributeMappings" $ List.byteGet AttributeMapping.byteGet
+  attributeMappings <- ByteGet.label "attributeMappings"
+    $ List.byteGet AttributeMapping.byteGet
   pure Cache { classId, parentCacheId, cacheId, attributeMappings }

--- a/src/lib/Rattletrap/Type/ClassMapping.hs
+++ b/src/lib/Rattletrap/Type/ClassMapping.hs
@@ -33,7 +33,7 @@ bytePut :: ClassMapping -> BytePut.BytePut
 bytePut x = Str.bytePut (name x) <> U32.bytePut (streamId x)
 
 byteGet :: ByteGet.ByteGet ClassMapping
-byteGet = do
-  name <- Str.byteGet
-  streamId <- U32.byteGet
+byteGet = ByteGet.label "ClassMapping" $ do
+  name <- ByteGet.label "name" Str.byteGet
+  streamId <- ByteGet.label "streamId" U32.byteGet
   pure ClassMapping { name, streamId }

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -195,13 +195,16 @@ byteGet matchType version numFrames maxChannels = ByteGet.label "Content" $ do
   levels <- ByteGet.label "levels" $ List.byteGet Str.byteGet
   keyframes <- ByteGet.label "keyframes" $ List.byteGet Keyframe.byteGet
   streamSize <- ByteGet.label "streamSize" U32.byteGet
-  stream <- ByteGet.label "stream" . ByteGet.byteString . fromIntegral $ U32.toWord32 streamSize
+  stream <-
+    ByteGet.label "stream" . ByteGet.byteString . fromIntegral $ U32.toWord32
+      streamSize
   messages <- ByteGet.label "messages" $ List.byteGet Message.byteGet
   marks <- ByteGet.label "marks" $ List.byteGet Mark.byteGet
   packages <- ByteGet.label "packages" $ List.byteGet Str.byteGet
   objects <- ByteGet.label "objects" $ List.byteGet Str.byteGet
   names <- ByteGet.label "names" $ List.byteGet Str.byteGet
-  classMappings <- ByteGet.label "classMappings" $ List.byteGet ClassMapping.byteGet
+  classMappings <- ByteGet.label "classMappings"
+    $ List.byteGet ClassMapping.byteGet
   caches <- ByteGet.label "caches" $ List.byteGet Cache.byteGet
   let
     classAttributeMap =
@@ -215,8 +218,10 @@ byteGet matchType version numFrames maxChannels = ByteGet.label "Content" $ do
         classAttributeMap
       )
       mempty
-  frames <- ByteGet.label "frames" $ ByteGet.embed (BitGet.toByteGet bitGet) stream
-  unknown <- ByteGet.label "unknown" $ fmap LazyByteString.unpack ByteGet.remaining
+  frames <- ByteGet.label "frames"
+    $ ByteGet.embed (BitGet.toByteGet bitGet) stream
+  unknown <- ByteGet.label "unknown"
+    $ fmap LazyByteString.unpack ByteGet.remaining
   pure Content
     { levels
     , keyframes

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -191,18 +191,18 @@ byteGet
   -- ^ The maximum number of channels in the stream, usually from
   -- 'Rattletrap.Header.getMaxChannels'.
   -> ByteGet.ByteGet Content
-byteGet matchType version numFrames maxChannels = do
-  levels <- List.byteGet Str.byteGet
-  keyframes <- List.byteGet Keyframe.byteGet
-  streamSize <- U32.byteGet
-  stream <- ByteGet.byteString . fromIntegral $ U32.toWord32 streamSize
-  messages <- List.byteGet Message.byteGet
-  marks <- List.byteGet Mark.byteGet
-  packages <- List.byteGet Str.byteGet
-  objects <- List.byteGet Str.byteGet
-  names <- List.byteGet Str.byteGet
-  classMappings <- List.byteGet ClassMapping.byteGet
-  caches <- List.byteGet Cache.byteGet
+byteGet matchType version numFrames maxChannels = ByteGet.label "Content" $ do
+  levels <- ByteGet.label "levels" $ List.byteGet Str.byteGet
+  keyframes <- ByteGet.label "keyframes" $ List.byteGet Keyframe.byteGet
+  streamSize <- ByteGet.label "streamSize" U32.byteGet
+  stream <- ByteGet.label "stream" . ByteGet.byteString . fromIntegral $ U32.toWord32 streamSize
+  messages <- ByteGet.label "messages" $ List.byteGet Message.byteGet
+  marks <- ByteGet.label "marks" $ List.byteGet Mark.byteGet
+  packages <- ByteGet.label "packages" $ List.byteGet Str.byteGet
+  objects <- ByteGet.label "objects" $ List.byteGet Str.byteGet
+  names <- ByteGet.label "names" $ List.byteGet Str.byteGet
+  classMappings <- ByteGet.label "classMappings" $ List.byteGet ClassMapping.byteGet
+  caches <- ByteGet.label "caches" $ List.byteGet Cache.byteGet
   let
     classAttributeMap =
       ClassAttributeMap.make objects classMappings caches names
@@ -215,8 +215,8 @@ byteGet matchType version numFrames maxChannels = do
         classAttributeMap
       )
       mempty
-  frames <- ByteGet.embed (BitGet.toByteGet bitGet) stream
-  unknown <- fmap LazyByteString.unpack ByteGet.remaining
+  frames <- ByteGet.label "frames" $ ByteGet.embed (BitGet.toByteGet bitGet) stream
+  unknown <- ByteGet.label "unknown" $ fmap LazyByteString.unpack ByteGet.remaining
   pure Content
     { levels
     , keyframes

--- a/src/lib/Rattletrap/Type/Dictionary.hs
+++ b/src/lib/Rattletrap/Type/Dictionary.hs
@@ -71,7 +71,7 @@ bytePut f x =
     <> Str.bytePut (lastKey x)
 
 byteGet :: ByteGet.ByteGet a -> ByteGet.ByteGet (Dictionary a)
-byteGet = byteGetWith 0 []
+byteGet = ByteGet.label "Dictionary" . byteGetWith 0 []
 
 byteGetWith
   :: Int
@@ -79,14 +79,14 @@ byteGetWith
   -> ByteGet.ByteGet a
   -> ByteGet.ByteGet (Dictionary a)
 byteGetWith i xs f = do
-  k <- Str.byteGet
+  k <- ByteGet.label ("key (" <> show i <> ")") Str.byteGet
   if isNone k
     then pure Dictionary
       { elements = List.fromList . reverse $ fmap snd xs
       , lastKey = k
       }
     else do
-      v <- f
+      v <- ByteGet.label ("value (" <> Str.toString k <> ")") f
       byteGetWith (i + 1) ((i, (k, v)) : xs) f
 
 isNone :: Str.Str -> Bool

--- a/src/lib/Rattletrap/Type/F32.hs
+++ b/src/lib/Rattletrap/Type/F32.hs
@@ -33,7 +33,7 @@ bitPut :: F32 -> BitPut.BitPut
 bitPut = BitPut.fromBytePut . bytePut
 
 byteGet :: ByteGet.ByteGet F32
-byteGet = fmap fromFloat ByteGet.float
+byteGet = ByteGet.label "F32" $ fmap fromFloat ByteGet.float
 
 bitGet :: BitGet.BitGet F32
 bitGet = BitGet.fromByteGet byteGet 4

--- a/src/lib/Rattletrap/Type/Header.hs
+++ b/src/lib/Rattletrap/Type/Header.hs
@@ -97,8 +97,9 @@ bytePut x =
     (properties x)
 
 byteGet :: ByteGet.ByteGet Header
-byteGet = do
-  version <- Version.byteGet
-  label <- Str.byteGet
-  properties <- Dictionary.byteGet Property.byteGet
+byteGet = ByteGet.label "Header" $ do
+  version <- ByteGet.label "version" Version.byteGet
+  label <- ByteGet.label "label" Str.byteGet
+  properties <- ByteGet.label "properties"
+    $ Dictionary.byteGet Property.byteGet
   pure Header { version, label, properties }

--- a/src/lib/Rattletrap/Type/I32.hs
+++ b/src/lib/Rattletrap/Type/I32.hs
@@ -38,7 +38,7 @@ bitPut :: I32 -> BitPut.BitPut
 bitPut = BitPut.fromBytePut . bytePut
 
 byteGet :: ByteGet.ByteGet I32
-byteGet = fmap fromInt32 ByteGet.int32
+byteGet = ByteGet.label "I32" $ fmap fromInt32 ByteGet.int32
 
 bitGet :: BitGet.BitGet I32
 bitGet = BitGet.fromByteGet byteGet 4

--- a/src/lib/Rattletrap/Type/Keyframe.hs
+++ b/src/lib/Rattletrap/Type/Keyframe.hs
@@ -43,8 +43,8 @@ bytePut x =
   F32.bytePut (time x) <> U32.bytePut (frame x) <> U32.bytePut (position x)
 
 byteGet :: ByteGet.ByteGet Keyframe
-byteGet = do
-  time <- F32.byteGet
-  frame <- U32.byteGet
-  position <- U32.byteGet
+byteGet = ByteGet.label "Keyframe" $ do
+  time <- ByteGet.label "time" F32.byteGet
+  frame <- ByteGet.label "frame" U32.byteGet
+  position <- ByteGet.label "position" U32.byteGet
   pure Keyframe { time, frame, position }

--- a/src/lib/Rattletrap/Type/List.hs
+++ b/src/lib/Rattletrap/Type/List.hs
@@ -36,9 +36,13 @@ bytePut f x =
   in (U32.bytePut . U32.fromWord32 . fromIntegral $ length v) <> foldMap f v
 
 byteGet :: ByteGet.ByteGet a -> ByteGet.ByteGet (List a)
-byteGet f = do
-  size <- U32.byteGet
-  replicateM (fromIntegral $ U32.toWord32 size) f
+byteGet f = ByteGet.label "List" $ do
+  size <- ByteGet.label "size" U32.byteGet
+  generateM (fromIntegral $ U32.toWord32 size)
+    $ \i -> ByteGet.label ("element (" <> show i <> ")") f
+
+generateM :: Monad m => Int -> (Int -> m a) -> m (List a)
+generateM n f = fmap fromList $ mapM f [0 .. n]
 
 replicateM :: Monad m => Int -> m a -> m (List a)
 replicateM n = fmap fromList . Monad.replicateM n

--- a/src/lib/Rattletrap/Type/List.hs
+++ b/src/lib/Rattletrap/Type/List.hs
@@ -42,7 +42,7 @@ byteGet f = ByteGet.label "List" $ do
     $ \i -> ByteGet.label ("element (" <> show i <> ")") f
 
 generateM :: Monad m => Int -> (Int -> m a) -> m (List a)
-generateM n f = fmap fromList $ mapM f [0 .. n]
+generateM n f = fmap fromList $ mapM f [0 .. n - 1]
 
 replicateM :: Monad m => Int -> m a -> m (List a)
 replicateM n = fmap fromList . Monad.replicateM n

--- a/src/lib/Rattletrap/Type/Mark.hs
+++ b/src/lib/Rattletrap/Type/Mark.hs
@@ -35,7 +35,7 @@ bytePut :: Mark -> BytePut.BytePut
 bytePut x = Str.bytePut (value x) <> U32.bytePut (frame x)
 
 byteGet :: ByteGet.ByteGet Mark
-byteGet = do
-  value <- Str.byteGet
-  frame <- U32.byteGet
+byteGet = ByteGet.label "Mark" $ do
+  value <- ByteGet.label "value" Str.byteGet
+  frame <- ByteGet.label "frame" U32.byteGet
   pure Mark { value, frame }

--- a/src/lib/Rattletrap/Type/Message.hs
+++ b/src/lib/Rattletrap/Type/Message.hs
@@ -43,8 +43,8 @@ bytePut x =
   U32.bytePut (frame x) <> Str.bytePut (name x) <> Str.bytePut (value x)
 
 byteGet :: ByteGet.ByteGet Message
-byteGet = do
-  frame <- U32.byteGet
-  name <- Str.byteGet
-  value <- Str.byteGet
+byteGet = ByteGet.label "Message" $ do
+  frame <- ByteGet.label "frame" U32.byteGet
+  name <- ByteGet.label "name" Str.byteGet
+  value <- ByteGet.label "value" Str.byteGet
   pure Message { frame, name, value }

--- a/src/lib/Rattletrap/Type/Property.hs
+++ b/src/lib/Rattletrap/Type/Property.hs
@@ -44,8 +44,8 @@ bytePut x =
     (value x)
 
 byteGet :: ByteGet.ByteGet Property
-byteGet = do
-  kind <- Str.byteGet
-  size <- U64.byteGet
-  value <- PropertyValue.byteGet byteGet kind
+byteGet = ByteGet.label "Property" $ do
+  kind <- ByteGet.label "kind" Str.byteGet
+  size <- ByteGet.label "size" U64.byteGet
+  value <- ByteGet.label "value" $ PropertyValue.byteGet byteGet kind
   pure Property { kind, size, value }

--- a/src/lib/Rattletrap/Type/Property/Array.hs
+++ b/src/lib/Rattletrap/Type/Property/Array.hs
@@ -32,4 +32,5 @@ bytePut :: (a -> BytePut.BytePut) -> Array a -> BytePut.BytePut
 bytePut f = List.bytePut (Dictionary.bytePut f) . toList
 
 byteGet :: ByteGet.ByteGet a -> ByteGet.ByteGet (Array a)
-byteGet f = fmap fromList $ List.byteGet (Dictionary.byteGet f)
+byteGet =
+  ByteGet.label "Array" . fmap fromList . List.byteGet . Dictionary.byteGet

--- a/src/lib/Rattletrap/Type/Property/Bool.hs
+++ b/src/lib/Rattletrap/Type/Property/Bool.hs
@@ -30,4 +30,4 @@ bytePut :: Bool -> BytePut.BytePut
 bytePut = U8.bytePut . toU8
 
 byteGet :: ByteGet.ByteGet Bool
-byteGet = fmap fromU8 U8.byteGet
+byteGet = ByteGet.label "Bool" $ fmap fromU8 U8.byteGet

--- a/src/lib/Rattletrap/Type/Property/Byte.hs
+++ b/src/lib/Rattletrap/Type/Property/Byte.hs
@@ -29,9 +29,9 @@ bytePut :: Byte -> BytePut.BytePut
 bytePut byte = Str.bytePut (key byte) <> foldMap Str.bytePut (value byte)
 
 byteGet :: ByteGet.ByteGet Byte
-byteGet = do
-  key <- Str.byteGet
-  value <- Monad.whenMaybe
+byteGet = ByteGet.label "Byte" $ do
+  key <- ByteGet.label "key" Str.byteGet
+  value <- ByteGet.label "value" $ Monad.whenMaybe
     (Str.toString key /= "OnlinePlatform_Steam")
     Str.byteGet
   pure Byte { key, value }

--- a/src/lib/Rattletrap/Type/Property/Float.hs
+++ b/src/lib/Rattletrap/Type/Property/Float.hs
@@ -30,4 +30,4 @@ bytePut :: Float -> BytePut.BytePut
 bytePut = F32.bytePut . toF32
 
 byteGet :: ByteGet.ByteGet Float
-byteGet = fmap fromF32 F32.byteGet
+byteGet = ByteGet.label "Float" $ fmap fromF32 F32.byteGet

--- a/src/lib/Rattletrap/Type/Property/Int.hs
+++ b/src/lib/Rattletrap/Type/Property/Int.hs
@@ -30,4 +30,4 @@ bytePut :: Int -> BytePut.BytePut
 bytePut = I32.bytePut . toI32
 
 byteGet :: ByteGet.ByteGet Int
-byteGet = fmap fromI32 I32.byteGet
+byteGet = ByteGet.label "I32" $ fmap fromI32 I32.byteGet

--- a/src/lib/Rattletrap/Type/Property/Name.hs
+++ b/src/lib/Rattletrap/Type/Property/Name.hs
@@ -29,4 +29,4 @@ bytePut :: Name -> BytePut.BytePut
 bytePut = Str.bytePut . toStr
 
 byteGet :: ByteGet.ByteGet Name
-byteGet = fmap fromStr Str.byteGet
+byteGet = ByteGet.label "Name" $ fmap fromStr Str.byteGet

--- a/src/lib/Rattletrap/Type/Property/QWord.hs
+++ b/src/lib/Rattletrap/Type/Property/QWord.hs
@@ -29,4 +29,4 @@ bytePut :: QWord -> BytePut.BytePut
 bytePut = U64.bytePut . toU64
 
 byteGet :: ByteGet.ByteGet QWord
-byteGet = fmap fromU64 U64.byteGet
+byteGet = ByteGet.label "QWord" $ fmap fromU64 U64.byteGet

--- a/src/lib/Rattletrap/Type/Property/Str.hs
+++ b/src/lib/Rattletrap/Type/Property/Str.hs
@@ -29,4 +29,4 @@ bytePut :: Str -> BytePut.BytePut
 bytePut = Str.bytePut . toStr
 
 byteGet :: ByteGet.ByteGet Str
-byteGet = fmap fromStr Str.byteGet
+byteGet = ByteGet.label "Str" $ fmap fromStr Str.byteGet

--- a/src/lib/Rattletrap/Type/PropertyValue.hs
+++ b/src/lib/Rattletrap/Type/PropertyValue.hs
@@ -79,13 +79,14 @@ bytePut putProperty value = case value of
   Str x -> Property.Str.bytePut x
 
 byteGet :: ByteGet.ByteGet a -> Str.Str -> ByteGet.ByteGet (PropertyValue a)
-byteGet getProperty kind = case Str.toString kind of
-  "ArrayProperty" -> fmap Array $ Property.Array.byteGet getProperty
-  "BoolProperty" -> fmap Bool Property.Bool.byteGet
-  "ByteProperty" -> fmap Byte Property.Byte.byteGet
-  "FloatProperty" -> fmap Float Property.Float.byteGet
-  "IntProperty" -> fmap Int Property.Int.byteGet
-  "NameProperty" -> fmap Name Property.Name.byteGet
-  "QWordProperty" -> fmap QWord Property.QWord.byteGet
-  "StrProperty" -> fmap Str Property.Str.byteGet
-  x -> ByteGet.throw $ UnknownProperty.UnknownProperty x
+byteGet getProperty kind =
+  ByteGet.label "PropertyValue" $ case Str.toString kind of
+    "ArrayProperty" -> fmap Array $ Property.Array.byteGet getProperty
+    "BoolProperty" -> fmap Bool Property.Bool.byteGet
+    "ByteProperty" -> fmap Byte Property.Byte.byteGet
+    "FloatProperty" -> fmap Float Property.Float.byteGet
+    "IntProperty" -> fmap Int Property.Int.byteGet
+    "NameProperty" -> fmap Name Property.Name.byteGet
+    "QWordProperty" -> fmap QWord Property.QWord.byteGet
+    "StrProperty" -> fmap Str Property.Str.byteGet
+    x -> ByteGet.throw $ UnknownProperty.UnknownProperty x

--- a/src/lib/Rattletrap/Type/Str.hs
+++ b/src/lib/Rattletrap/Type/Str.hs
@@ -73,10 +73,10 @@ addNull :: Text.Text -> Text.Text
 addNull text = if Text.null text then text else Text.snoc text '\x00'
 
 byteGet :: ByteGet.ByteGet Str
-byteGet = do
-  rawSize <- I32.byteGet
-  bytes <- ByteGet.byteString (normalizeTextSize rawSize)
-  pure (fromText (dropNull (getTextDecoder rawSize bytes)))
+byteGet = ByteGet.label "Str" $ do
+  size <- ByteGet.label "size" I32.byteGet
+  bytes <- ByteGet.label "value" . ByteGet.byteString $ normalizeTextSize size
+  pure . fromText . dropNull $ getTextDecoder size bytes
 
 bitGet :: BitGet.BitGet Str
 bitGet = do

--- a/src/lib/Rattletrap/Type/U32.hs
+++ b/src/lib/Rattletrap/Type/U32.hs
@@ -38,7 +38,7 @@ bitPut :: U32 -> BitPut.BitPut
 bitPut = BitPut.fromBytePut . bytePut
 
 byteGet :: ByteGet.ByteGet U32
-byteGet = fmap fromWord32 ByteGet.word32
+byteGet = ByteGet.label "U32" $ fmap fromWord32 ByteGet.word32
 
 bitGet :: BitGet.BitGet U32
 bitGet = BitGet.fromByteGet byteGet 4

--- a/src/lib/Rattletrap/Type/U64.hs
+++ b/src/lib/Rattletrap/Type/U64.hs
@@ -42,7 +42,7 @@ bitPut :: U64 -> BitPut.BitPut
 bitPut = BitPut.fromBytePut . bytePut
 
 byteGet :: ByteGet.ByteGet U64
-byteGet = fmap fromWord64 ByteGet.word64
+byteGet = ByteGet.label "U64" $ fmap fromWord64 ByteGet.word64
 
 bitGet :: BitGet.BitGet U64
 bitGet = BitGet.fromByteGet byteGet 8

--- a/src/lib/Rattletrap/Type/U8.hs
+++ b/src/lib/Rattletrap/Type/U8.hs
@@ -38,7 +38,7 @@ bitPut :: U8 -> BitPut.BitPut
 bitPut = BitPut.fromBytePut . bytePut
 
 byteGet :: ByteGet.ByteGet U8
-byteGet = fmap fromWord8 ByteGet.word8
+byteGet = ByteGet.label "U8" $ fmap fromWord8 ByteGet.word8
 
 bitGet :: BitGet.BitGet U8
 bitGet = BitGet.fromByteGet byteGet 1

--- a/src/lib/Rattletrap/Type/Version.hs
+++ b/src/lib/Rattletrap/Type/Version.hs
@@ -24,10 +24,10 @@ bytePut x = U32.bytePut (major x) <> U32.bytePut (minor x) <> foldMap
   (patch x)
 
 byteGet :: ByteGet.ByteGet Version
-byteGet = do
-  major <- U32.byteGet
-  minor <- U32.byteGet
-  patch <- Monad.whenMaybe
+byteGet = ByteGet.label "Version" $ do
+  major <- ByteGet.label "major" U32.byteGet
+  minor <- ByteGet.label "minor" U32.byteGet
+  patch <- ByteGet.label "patch" $ Monad.whenMaybe
     (U32.toWord32 major >= 868 && U32.toWord32 minor >= 18)
     U32.byteGet
   pure Version { major, minor, patch }


### PR DESCRIPTION
This addresses part of #230 and builds on #231. It will add labels to all the `ByteGet` and `BitGet` stuff. The idea is that if something goes wrong it should be very clear which part of the program is to blame. 