### PR TITLE
Support Aeson 2.0

### DIFF
--- a/rattletrap.cabal
+++ b/rattletrap.cabal
@@ -51,7 +51,7 @@ library
 
   autogen-modules: Paths_rattletrap
   build-depends:
-    , aeson ^>= 1.5.6
+    , aeson ^>= 1.5.6 || ^>= 2.0.0
     , aeson-pretty ^>= 0.8.8
     , array ^>= 0.5.4
     , bytestring ^>= 0.10.12

--- a/src/lib/Rattletrap/Schema.hs
+++ b/src/lib/Rattletrap/Schema.hs
@@ -15,10 +15,10 @@ named n j = Schema { name = Text.pack n, json = j }
 ref :: Schema -> Json.Value
 ref s = Json.object [Json.pair "$ref" $ Text.pack "#/definitions/" <> name s]
 
-object :: [((Text.Text, Json.Value), Bool)] -> Json.Value
+object :: [((String, Json.Value), Bool)] -> Json.Value
 object xs = Json.object
   [ Json.pair "type" "object"
-  , Json.pair "properties" . Json.object $ fmap fst xs
+  , Json.pair "properties" . Json.object $ fmap (uncurry Json.pair . fst) xs
   , Json.pair "required" . fmap (fst . fst) $ filter snd xs
   ]
 

--- a/src/lib/Rattletrap/Utility/Json.hs
+++ b/src/lib/Rattletrap/Utility/Json.hs
@@ -1,4 +1,7 @@
+{- hlint ignore "Avoid restricted flags" -}
 {-# OPTIONS_GHC -Wno-orphans #-}
+
+{- hlint ignore "Avoid restricted extensions" -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 

--- a/src/lib/Rattletrap/Utility/Json.hs
+++ b/src/lib/Rattletrap/Utility/Json.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 module Rattletrap.Utility.Json
@@ -17,6 +18,19 @@ import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LazyByteString
+
+# if MIN_VERSION_aeson(2, 0, 0)
+
+import qualified Data.Aeson.Key as Key
+
+toKey :: String -> Key.Key
+toKey = Key.fromString
+
+fromKey :: Key.Key -> String
+fromKey = Key.toString
+
+# else
+
 import qualified Data.Text as Text
 
 toKey :: String -> Text.Text
@@ -24,6 +38,8 @@ toKey = Text.pack
 
 fromKey :: Text.Text -> String
 fromKey = Text.unpack
+
+# endif
 
 instance Aeson.KeyValue (String, Aeson.Value) where
   k .= v = (fromKey k, Aeson.toJSON v)

--- a/src/lib/Rattletrap/Utility/Json.hs
+++ b/src/lib/Rattletrap/Utility/Json.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
+
 module Rattletrap.Utility.Json
   ( module Rattletrap.Utility.Json
   , Aeson.FromJSON(parseJSON)
@@ -16,19 +19,28 @@ import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 
+toKey :: String -> Text.Text
+toKey = Text.pack
+
+fromKey :: Text.Text -> String
+fromKey = Text.unpack
+
+instance Aeson.KeyValue (String, Aeson.Value) where
+  k .= v = (fromKey k, Aeson.toJSON v)
+
 required
   :: Aeson.FromJSON value => Aeson.Object -> String -> Aeson.Parser value
-required object key = object Aeson..: Text.pack key
+required object key = object Aeson..: toKey key
 
 optional
   :: Aeson.FromJSON value
   => Aeson.Object
   -> String
   -> Aeson.Parser (Maybe value)
-optional object key = object Aeson..:? Text.pack key
+optional object key = object Aeson..:? toKey key
 
 pair :: (Aeson.ToJSON value, Aeson.KeyValue pair) => String -> value -> pair
-pair key value = Text.pack key Aeson..= value
+pair key value = toKey key Aeson..= value
 
 decode :: Aeson.FromJSON a => ByteString.ByteString -> Either String a
 decode = Aeson.eitherDecodeStrict'


### PR DESCRIPTION
Prompted by https://github.com/commercialhaskell/stackage/issues/6217.

Obviously the surface area on my side is small, but supporting this is still a pain in the ass.

- Super major version bump (from 1.5 to 2.0) requires clunky version ranges (like `^>= 1.5 || ^>= 2.0`). If it was a normal major version bump this would be easy (`>= 1.5 && < 1.7`). The same thing happened back in the day with Aeson 0.11 to 1.0. 
- No migration guide was provided: https://github.com/haskell/aeson/issues/881
- [The change log](https://hackage.haskell.org/package/aeson-2.0.1.0/changelog) doesn't highlight the severity and importance of this: https://twitter.com/ChShersh/status/1446920962528714761
- Some things are completely missing from the change log, such as the new `Key` type, which is now pervasive through Aeson's API: https://github.com/haskell/aeson/pull/868
- Apparently no effort was made for forwards compatibility, like introducing `type Key = Text` or releasing a new 1.5.x version that makes migration easier. 
- Intuitively you'd think Rattletrap wouldn't have to change at all, since it doesn't care about the representation of JSON objects. And yet since unrelated changes were bundled into this release, I'm forced to deal with them using CPP (or something equivalent). 