### PR TITLE
Hide Data.List.List from import

### DIFF
--- a/src/lib/Rattletrap/Type/ClassAttributeMap.hs
+++ b/src/lib/Rattletrap/Type/ClassAttributeMap.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module Rattletrap.Type.ClassAttributeMap where
 
 import qualified Data.IntMap as IntMap
+#if MIN_VERSION_base(4,20,0)
+import qualified Data.List as List hiding (List)
+#else
 import qualified Data.List as List
+#endif
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set


### PR DESCRIPTION
This PR hides the `Data.List.List` identifier from the Data.List import.

Since the identifier will arrive with [base-4.20.0.0](https://gitlab.haskell.org/ghc/ghc/-/blob/2776920e642544477a38d0ed9205d4f0b48a782e/libraries/base/changelog.md#42000-tba), this hiding is guarded behind a CPP conditional.