### PR TITLE
Avoid ambiguous `List` import alias

### DIFF
--- a/src/lib/Rattletrap/Console/Main.hs
+++ b/src/lib/Rattletrap/Console/Main.hs
@@ -74,7 +74,7 @@ import qualified Rattletrap.Type.I8 as I8
 import qualified Rattletrap.Type.Initialization as Initialization
 import qualified Rattletrap.Type.Int8Vector as Int8Vector
 import qualified Rattletrap.Type.Keyframe as Keyframe
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Mark as Mark
 import qualified Rattletrap.Type.Message as Message
 import qualified Rattletrap.Type.Property as Property
@@ -162,7 +162,7 @@ defaultMain name config = do
 
 schema :: Json.Value
 schema =
-  let contentSchema = Content.schema $ List.schema Frame.schema
+  let contentSchema = Content.schema $ RList.schema Frame.schema
    in Json.object
         [ Json.pair "$schema" "http://json-schema.org/draft-07/schema",
           Json.pair "$id" Replay.schemaUrl,
@@ -231,7 +231,7 @@ schema =
                 Initialization.schema,
                 Int8Vector.schema,
                 Keyframe.schema,
-                List.schema Attribute.Product.schema,
+                RList.schema Attribute.Product.schema,
                 Mark.schema,
                 Message.schema,
                 Property.schema,

--- a/src/lib/Rattletrap/Type/Attribute/LoadoutOnline.hs
+++ b/src/lib/Rattletrap/Type/Attribute/LoadoutOnline.hs
@@ -5,7 +5,7 @@ import qualified Rattletrap.BitGet as BitGet
 import qualified Rattletrap.BitPut as BitPut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Attribute.Product as Product
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.U8 as U8
@@ -13,7 +13,7 @@ import qualified Rattletrap.Type.Version as Version
 import qualified Rattletrap.Utility.Json as Json
 
 newtype LoadoutOnline = LoadoutOnline
-  { value :: List.List (List.List Product.Product)
+  { value :: RList.List (RList.List Product.Product)
   }
   deriving (Eq, Show)
 
@@ -27,12 +27,12 @@ schema :: Schema.Schema
 schema =
   Schema.named "attribute-loadout-online"
     . Schema.json
-    . List.schema
-    $ List.schema Product.schema
+    . RList.schema
+    $ RList.schema Product.schema
 
 bitPut :: LoadoutOnline -> BitPut.BitPut
 bitPut loadoutAttribute =
-  let attributes = List.toList $ value loadoutAttribute
+  let attributes = RList.toList $ value loadoutAttribute
    in (U8.bitPut . U8.fromWord8 . fromIntegral $ length attributes)
         <> foldMap Product.putProductAttributes attributes
 
@@ -42,6 +42,6 @@ bitGet version objectMap = BitGet.label "LoadoutOnline" $ do
   size <- BitGet.label "size" U8.bitGet
   value <-
     BitGet.label "value"
-      . List.replicateM (fromIntegral $ U8.toWord8 size)
+      . RList.replicateM (fromIntegral $ U8.toWord8 size)
       $ Product.decodeProductAttributesBits version objectMap
   pure LoadoutOnline {value}

--- a/src/lib/Rattletrap/Type/Attribute/Product.hs
+++ b/src/lib/Rattletrap/Type/Attribute/Product.hs
@@ -5,7 +5,7 @@ import qualified Rattletrap.BitGet as BitGet
 import qualified Rattletrap.BitPut as BitPut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Attribute.ProductValue as ProductValue
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.U8 as U8
@@ -48,9 +48,9 @@ schema =
         (Json.pair "value" $ Schema.ref ProductValue.schema, True)
       ]
 
-putProductAttributes :: List.List Product -> BitPut.BitPut
+putProductAttributes :: RList.List Product -> BitPut.BitPut
 putProductAttributes attributes =
-  let v = List.toList attributes
+  let v = RList.toList attributes
    in (U8.bitPut . U8.fromWord8 . fromIntegral $ length v) <> foldMap bitPut v
 
 bitPut :: Product -> BitPut.BitPut
@@ -62,10 +62,10 @@ bitPut attribute =
 decodeProductAttributesBits ::
   Version.Version ->
   Map.Map U32.U32 Str.Str ->
-  BitGet.BitGet (List.List Product)
+  BitGet.BitGet (RList.List Product)
 decodeProductAttributesBits version objectMap = do
   size <- U8.bitGet
-  List.replicateM (fromIntegral $ U8.toWord8 size) $ bitGet version objectMap
+  RList.replicateM (fromIntegral $ U8.toWord8 size) $ bitGet version objectMap
 
 bitGet :: Version.Version -> Map.Map U32.U32 Str.Str -> BitGet.BitGet Product
 bitGet version objectMap = BitGet.label "Product" $ do

--- a/src/lib/Rattletrap/Type/Cache.hs
+++ b/src/lib/Rattletrap/Type/Cache.hs
@@ -4,7 +4,7 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.AttributeMapping as AttributeMapping
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Utility.Json as Json
 
@@ -12,7 +12,7 @@ data Cache = Cache
   { classId :: U32.U32,
     parentCacheId :: U32.U32,
     cacheId :: U32.U32,
-    attributeMappings :: List.List AttributeMapping.AttributeMapping
+    attributeMappings :: RList.List AttributeMapping.AttributeMapping
   }
   deriving (Eq, Show)
 
@@ -41,7 +41,7 @@ schema =
         (Json.pair "parent_cache_id" $ Schema.ref U32.schema, True),
         (Json.pair "cache_id" $ Schema.ref U32.schema, True),
         ( Json.pair "attribute_mappings" . Schema.json $
-            List.schema
+            RList.schema
               AttributeMapping.schema,
           True
         )
@@ -52,7 +52,7 @@ bytePut x =
   U32.bytePut (classId x)
     <> U32.bytePut (parentCacheId x)
     <> U32.bytePut (cacheId x)
-    <> List.bytePut AttributeMapping.bytePut (attributeMappings x)
+    <> RList.bytePut AttributeMapping.bytePut (attributeMappings x)
 
 byteGet :: ByteGet.ByteGet Cache
 byteGet = ByteGet.label "Cache" $ do
@@ -61,5 +61,5 @@ byteGet = ByteGet.label "Cache" $ do
   cacheId <- ByteGet.label "cacheId" U32.byteGet
   attributeMappings <-
     ByteGet.label "attributeMappings" $
-      List.byteGet AttributeMapping.byteGet
+      RList.byteGet AttributeMapping.byteGet
   pure Cache {classId, parentCacheId, cacheId, attributeMappings}

--- a/src/lib/Rattletrap/Type/ClassAttributeMap.hs
+++ b/src/lib/Rattletrap/Type/ClassAttributeMap.hs
@@ -12,7 +12,7 @@ import qualified Rattletrap.Type.AttributeMapping as AttributeMapping
 import qualified Rattletrap.Type.Cache as Cache
 import qualified Rattletrap.Type.ClassMapping as ClassMapping
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 
@@ -48,13 +48,13 @@ lookupR k = Map.lookup k . snd
 -- 'Rattletrap.Content.Content'.
 make ::
   -- | From 'Rattletrap.Content.objects'.
-  List.List Str.Str ->
+  RList.List Str.Str ->
   -- | From 'Rattletrap.Content.classMappings'.
-  List.List ClassMapping.ClassMapping ->
+  RList.List ClassMapping.ClassMapping ->
   -- | From 'Rattletrap.Content.caches'.
-  List.List Cache.Cache ->
+  RList.List Cache.Cache ->
   -- | From 'Rattletrap.Content.names'.
-  List.List Str.Str ->
+  RList.List Str.Str ->
   ClassAttributeMap
 make objects classMappings caches names =
   let objectMap_ = makeObjectMap objects
@@ -88,9 +88,9 @@ make objects classMappings caches names =
       nameMap_ = makeNameMap names
    in ClassAttributeMap objectMap_ objectClassMap_ value_ nameMap_
 
-makeNameMap :: List.List Str.Str -> IntMap.IntMap Str.Str
+makeNameMap :: RList.List Str.Str -> IntMap.IntMap Str.Str
 makeNameMap names =
-  IntMap.fromDistinctAscList (zip [0 ..] (List.toList names))
+  IntMap.fromDistinctAscList (zip [0 ..] (RList.toList names))
 
 getName :: IntMap.IntMap Str.Str -> U32.U32 -> Maybe Str.Str
 getName nameMap_ nameIndex =
@@ -125,7 +125,7 @@ getClassId objectMap_ classMap objectId = do
 
 makeClassCache ::
   Bimap U32.U32 Str.Str ->
-  List.List Cache.Cache ->
+  RList.List Cache.Cache ->
   [(Maybe Str.Str, U32.U32, U32.U32, U32.U32)]
 makeClassCache classMap caches =
   fmap
@@ -137,20 +137,20 @@ makeClassCache classMap caches =
               Cache.parentCacheId cache
             )
     )
-    (List.toList caches)
+    (RList.toList caches)
 
-makeClassMap :: List.List ClassMapping.ClassMapping -> Bimap U32.U32 Str.Str
+makeClassMap :: RList.List ClassMapping.ClassMapping -> Bimap U32.U32 Str.Str
 makeClassMap classMappings =
   bimap
     ( fmap
         ( \classMapping ->
             (ClassMapping.streamId classMapping, ClassMapping.name classMapping)
         )
-        (List.toList classMappings)
+        (RList.toList classMappings)
     )
 
 makeAttributeMap ::
-  List.List Cache.Cache -> Map.Map U32.U32 (Map.Map U32.U32 U32.U32)
+  RList.List Cache.Cache -> Map.Map U32.U32 (Map.Map U32.U32 U32.U32)
 makeAttributeMap caches =
   Map.fromList
     ( fmap
@@ -163,11 +163,11 @@ makeAttributeMap caches =
                           AttributeMapping.objectId attributeMapping
                         )
                     )
-                    (List.toList (Cache.attributeMappings cache))
+                    (RList.toList (Cache.attributeMappings cache))
                 )
             )
         )
-        (List.toList caches)
+        (RList.toList caches)
     )
 
 makeShallowParentMap ::
@@ -248,9 +248,9 @@ getParentClassByName className parentCacheId xs =
             )
         )
 
-makeObjectMap :: List.List Str.Str -> Map.Map U32.U32 Str.Str
+makeObjectMap :: RList.List Str.Str -> Map.Map U32.U32 Str.Str
 makeObjectMap objects =
-  Map.fromAscList (zip (fmap U32.fromWord32 [0 ..]) (List.toList objects))
+  Map.fromAscList (zip (fmap U32.fromWord32 [0 ..]) (RList.toList objects))
 
 getObjectName :: Map.Map U32.U32 Str.Str -> U32.U32 -> Maybe Str.Str
 getObjectName objectMap_ objectId = Map.lookup objectId objectMap_

--- a/src/lib/Rattletrap/Type/Content.hs
+++ b/src/lib/Rattletrap/Type/Content.hs
@@ -13,7 +13,7 @@ import qualified Rattletrap.Type.ClassAttributeMap as ClassAttributeMap
 import qualified Rattletrap.Type.ClassMapping as ClassMapping
 import qualified Rattletrap.Type.Frame as Frame
 import qualified Rattletrap.Type.Keyframe as Keyframe
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Mark as Mark
 import qualified Rattletrap.Type.Message as Message
 import qualified Rattletrap.Type.Str as Str
@@ -23,40 +23,40 @@ import qualified Rattletrap.Type.Version as Version
 import qualified Rattletrap.Utility.Bytes as Bytes
 import qualified Rattletrap.Utility.Json as Json
 
-type Content = ContentWith (List.List Frame.Frame)
+type Content = ContentWith (RList.List Frame.Frame)
 
 -- | Contains low-level game data about a 'Rattletrap.Replay.Replay'.
 data ContentWith frames = Content
   { -- | This typically only has one element, like @stadium_oob_audio_map@.
-    levels :: List.List Str.Str,
+    levels :: RList.List Str.Str,
     -- | A list of which frames are key frames. Although they aren't necessary
     -- for replay, key frames are frames that replicate every actor. They
     -- typically happen once every 10 seconds.
-    keyframes :: List.List Keyframe.Keyframe,
+    keyframes :: RList.List Keyframe.Keyframe,
     -- | The size of the stream in bytes. This is only really necessary because
     -- the stream has some arbitrary amount of padding at the end.
     streamSize :: U32.U32,
     -- | The actual game data. This is where all the interesting information is.
     frames :: frames,
     -- | Debugging messages. In newer replays, this is always empty.
-    messages :: List.List Message.Message,
+    messages :: RList.List Message.Message,
     -- | Tick marks shown on the scrubber when watching a replay.
-    marks :: List.List Mark.Mark,
+    marks :: RList.List Mark.Mark,
     -- | A list of @.upk@ files to load, like
     -- @..\\..\\TAGame\\CookedPCConsole\\Stadium_P.upk@.
-    packages :: List.List Str.Str,
+    packages :: RList.List Str.Str,
     -- | Objects in the stream. Used for the
     -- 'Rattletrap.Type.ClassAttributeMap.ClassAttributeMap'.
-    objects :: List.List Str.Str,
+    objects :: RList.List Str.Str,
     -- | It's not clear what these are used for. This list is usually not empty,
     -- but appears unused otherwise.
-    names :: List.List Str.Str,
+    names :: RList.List Str.Str,
     -- | A mapping between classes and their ID in the stream. Used for the
     -- 'Rattletrap.Type.ClassAttributeMap.ClassAttributeMap'.
-    classMappings :: List.List ClassMapping.ClassMapping,
+    classMappings :: RList.List ClassMapping.ClassMapping,
     -- | A list of classes along with their parent classes and attributes. Used
     -- for the 'Rattletrap.Type.ClassAttributeMap.ClassAttributeMap'.
-    caches :: List.List Cache.Cache,
+    caches :: RList.List Cache.Cache,
     unknown :: [Word.Word8]
   }
   deriving (Eq, Show)
@@ -112,53 +112,53 @@ schema :: Schema.Schema -> Schema.Schema
 schema s =
   Schema.named "content" $
     Schema.object
-      [ (Json.pair "levels" . Schema.json $ List.schema Str.schema, True),
-        (Json.pair "key_frames" . Schema.json $ List.schema Keyframe.schema, True),
+      [ (Json.pair "levels" . Schema.json $ RList.schema Str.schema, True),
+        (Json.pair "key_frames" . Schema.json $ RList.schema Keyframe.schema, True),
         (Json.pair "stream_size" $ Schema.ref U32.schema, True),
         (Json.pair "frames" $ Schema.json s, True),
-        (Json.pair "messages" . Schema.json $ List.schema Message.schema, True),
-        (Json.pair "marks" . Schema.json $ List.schema Mark.schema, True),
-        (Json.pair "packages" . Schema.json $ List.schema Str.schema, True),
-        (Json.pair "objects" . Schema.json $ List.schema Str.schema, True),
-        (Json.pair "names" . Schema.json $ List.schema Str.schema, True),
+        (Json.pair "messages" . Schema.json $ RList.schema Message.schema, True),
+        (Json.pair "marks" . Schema.json $ RList.schema Mark.schema, True),
+        (Json.pair "packages" . Schema.json $ RList.schema Str.schema, True),
+        (Json.pair "objects" . Schema.json $ RList.schema Str.schema, True),
+        (Json.pair "names" . Schema.json $ RList.schema Str.schema, True),
         ( Json.pair "class_mappings" . Schema.json $
-            List.schema
+            RList.schema
               ClassMapping.schema,
           True
         ),
-        (Json.pair "caches" . Schema.json $ List.schema Cache.schema, True),
+        (Json.pair "caches" . Schema.json $ RList.schema Cache.schema, True),
         (Json.pair "unknown" . Schema.json $ Schema.array U8.schema, True)
       ]
 
 empty :: Content
 empty =
   Content
-    { levels = List.empty,
-      keyframes = List.empty,
+    { levels = RList.empty,
+      keyframes = RList.empty,
       streamSize = U32.fromWord32 0,
-      frames = List.empty,
-      messages = List.empty,
-      marks = List.empty,
-      packages = List.empty,
-      objects = List.empty,
-      names = List.empty,
-      classMappings = List.empty,
-      caches = List.empty,
+      frames = RList.empty,
+      messages = RList.empty,
+      marks = RList.empty,
+      packages = RList.empty,
+      objects = RList.empty,
+      names = RList.empty,
+      classMappings = RList.empty,
+      caches = RList.empty,
       unknown = []
     }
 
 bytePut :: Content -> BytePut.BytePut
 bytePut x =
-  List.bytePut Str.bytePut (levels x)
-    <> List.bytePut Keyframe.bytePut (keyframes x)
+  RList.bytePut Str.bytePut (levels x)
+    <> RList.bytePut Keyframe.bytePut (keyframes x)
     <> putFrames x
-    <> List.bytePut Message.bytePut (messages x)
-    <> List.bytePut Mark.bytePut (marks x)
-    <> List.bytePut Str.bytePut (packages x)
-    <> List.bytePut Str.bytePut (objects x)
-    <> List.bytePut Str.bytePut (names x)
-    <> List.bytePut ClassMapping.bytePut (classMappings x)
-    <> List.bytePut Cache.bytePut (caches x)
+    <> RList.bytePut Message.bytePut (messages x)
+    <> RList.bytePut Mark.bytePut (marks x)
+    <> RList.bytePut Str.bytePut (packages x)
+    <> RList.bytePut Str.bytePut (objects x)
+    <> RList.bytePut Str.bytePut (names x)
+    <> RList.bytePut ClassMapping.bytePut (classMappings x)
+    <> RList.bytePut Cache.bytePut (caches x)
     <> foldMap BytePut.word8 (unknown x)
 
 putFrames :: Content -> BytePut.BytePut
@@ -199,22 +199,22 @@ byteGet ::
   ByteGet.ByteGet Content
 byteGet matchType version numFrames maxChannels buildVersion =
   ByteGet.label "Content" $ do
-    levels <- ByteGet.label "levels" $ List.byteGet Str.byteGet
-    keyframes <- ByteGet.label "keyframes" $ List.byteGet Keyframe.byteGet
+    levels <- ByteGet.label "levels" $ RList.byteGet Str.byteGet
+    keyframes <- ByteGet.label "keyframes" $ RList.byteGet Keyframe.byteGet
     streamSize <- ByteGet.label "streamSize" U32.byteGet
     stream <-
       ByteGet.label "stream" . ByteGet.byteString . fromIntegral $
         U32.toWord32
           streamSize
-    messages <- ByteGet.label "messages" $ List.byteGet Message.byteGet
-    marks <- ByteGet.label "marks" $ List.byteGet Mark.byteGet
-    packages <- ByteGet.label "packages" $ List.byteGet Str.byteGet
-    objects <- ByteGet.label "objects" $ List.byteGet Str.byteGet
-    names <- ByteGet.label "names" $ List.byteGet Str.byteGet
+    messages <- ByteGet.label "messages" $ RList.byteGet Message.byteGet
+    marks <- ByteGet.label "marks" $ RList.byteGet Mark.byteGet
+    packages <- ByteGet.label "packages" $ RList.byteGet Str.byteGet
+    objects <- ByteGet.label "objects" $ RList.byteGet Str.byteGet
+    names <- ByteGet.label "names" $ RList.byteGet Str.byteGet
     classMappings <-
       ByteGet.label "classMappings" $
-        List.byteGet ClassMapping.byteGet
-    caches <- ByteGet.label "caches" $ List.byteGet Cache.byteGet
+        RList.byteGet ClassMapping.byteGet
+    caches <- ByteGet.label "caches" $ RList.byteGet Cache.byteGet
     let classAttributeMap =
           ClassAttributeMap.make objects classMappings caches names
         getFrames =

--- a/src/lib/Rattletrap/Type/Frame.hs
+++ b/src/lib/Rattletrap/Type/Frame.hs
@@ -7,7 +7,7 @@ import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.ClassAttributeMap as ClassAttributeMap
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
 import qualified Rattletrap.Type.F32 as F32
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Replication as Replication
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
@@ -20,7 +20,7 @@ data Frame = Frame
     -- | Time in seconds since the last frame. Usually about 0.03 since there
     -- are 30 frames per second.
     delta :: F32.F32,
-    replications :: List.List Replication.Replication
+    replications :: RList.List Replication.Replication
   }
   deriving (Eq, Show)
 
@@ -45,13 +45,13 @@ schema =
     Schema.object
       [ (Json.pair "time" $ Schema.ref F32.schema, True),
         (Json.pair "delta" $ Schema.ref F32.schema, True),
-        ( Json.pair "replications" . Schema.json $ List.schema Replication.schema,
+        ( Json.pair "replications" . Schema.json $ RList.schema Replication.schema,
           True
         )
       ]
 
-putFrames :: List.List Frame -> BitPut.BitPut
-putFrames = foldMap bitPut . List.toList
+putFrames :: RList.List Frame -> BitPut.BitPut
+putFrames = foldMap bitPut . RList.toList
 
 bitPut :: Frame -> BitPut.BitPut
 bitPut frame =
@@ -66,7 +66,7 @@ decodeFramesBits ::
   Int ->
   Word ->
   ClassAttributeMap.ClassAttributeMap ->
-  BitGet.BitGet (List.List Frame)
+  BitGet.BitGet (RList.List Frame)
 decodeFramesBits matchType version buildVersion count limit classes =
   fmap snd $
     decodeFramesBitsWith
@@ -94,11 +94,11 @@ decodeFramesBitsWith ::
     ( Map.Map
         CompressedWord.CompressedWord
         U32.U32,
-      List.List Frame
+      RList.List Frame
     )
 decodeFramesBitsWith matchType version buildVersion count limit classes actorMap index frames =
   if index >= count
-    then pure (actorMap, List.fromList $ reverse frames)
+    then pure (actorMap, RList.fromList $ reverse frames)
     else do
       (newActorMap, frame) <-
         BitGet.label ("element (" <> show index <> ")") $

--- a/src/lib/Rattletrap/Type/Property/Array.hs
+++ b/src/lib/Rattletrap/Type/Property/Array.hs
@@ -4,17 +4,17 @@ import qualified Rattletrap.ByteGet as ByteGet
 import qualified Rattletrap.BytePut as BytePut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Dictionary as Dictionary
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Utility.Json as Json
 
 newtype Array a
-  = Array (List.List (Dictionary.Dictionary a))
+  = Array (RList.List (Dictionary.Dictionary a))
   deriving (Eq, Show)
 
-fromList :: List.List (Dictionary.Dictionary a) -> Array a
+fromList :: RList.List (Dictionary.Dictionary a) -> Array a
 fromList = Array
 
-toList :: Array a -> List.List (Dictionary.Dictionary a)
+toList :: Array a -> RList.List (Dictionary.Dictionary a)
 toList (Array x) = x
 
 instance (Json.FromJSON a) => Json.FromJSON (Array a) where
@@ -25,13 +25,13 @@ instance (Json.ToJSON a) => Json.ToJSON (Array a) where
 
 schema :: Schema.Schema -> Schema.Schema
 schema s =
-  Schema.named "property-array" . Schema.json . List.schema $
+  Schema.named "property-array" . Schema.json . RList.schema $
     Dictionary.schema
       s
 
 bytePut :: (a -> BytePut.BytePut) -> Array a -> BytePut.BytePut
-bytePut f = List.bytePut (Dictionary.bytePut f) . toList
+bytePut f = RList.bytePut (Dictionary.bytePut f) . toList
 
 byteGet :: ByteGet.ByteGet a -> ByteGet.ByteGet (Array a)
 byteGet =
-  ByteGet.label "Array" . fmap fromList . List.byteGet . Dictionary.byteGet
+  ByteGet.label "Array" . fmap fromList . RList.byteGet . Dictionary.byteGet

--- a/src/lib/Rattletrap/Type/Replication.hs
+++ b/src/lib/Rattletrap/Type/Replication.hs
@@ -6,7 +6,7 @@ import qualified Rattletrap.BitPut as BitPut
 import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.ClassAttributeMap as ClassAttributeMap
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.ReplicationValue as ReplicationValue
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
@@ -37,9 +37,9 @@ schema =
         (Json.pair "value" $ Schema.ref ReplicationValue.schema, True)
       ]
 
-putReplications :: List.List Replication -> BitPut.BitPut
+putReplications :: RList.List Replication -> BitPut.BitPut
 putReplications xs =
-  foldMap (\x -> BitPut.bool True <> bitPut x) (List.toList xs)
+  foldMap (\x -> BitPut.bool True <> bitPut x) (RList.toList xs)
     <> BitPut.bool False
 
 bitPut :: Replication -> BitPut.BitPut
@@ -56,7 +56,7 @@ decodeReplicationsBits ::
   Map.Map CompressedWord.CompressedWord U32.U32 ->
   BitGet.BitGet
     ( Map.Map CompressedWord.CompressedWord U32.U32,
-      List.List Replication
+      RList.List Replication
     )
 decodeReplicationsBits matchType version buildVersion limit classes actorMap =
   decodeReplicationsBitsWith
@@ -80,7 +80,7 @@ decodeReplicationsBitsWith ::
   [Replication] ->
   BitGet.BitGet
     ( Map.Map CompressedWord.CompressedWord U32.U32,
-      List.List Replication
+      RList.List Replication
     )
 decodeReplicationsBitsWith matchType version buildVersion limit classes actorMap index replications =
   do
@@ -100,7 +100,7 @@ decodeReplicationsBitsWith matchType version buildVersion limit classes actorMap
           (index + 1)
           $ replication
             : replications
-      else pure (actorMap, List.fromList $ reverse replications)
+      else pure (actorMap, RList.fromList $ reverse replications)
 
 bitGet ::
   Maybe Str.Str ->

--- a/src/lib/Rattletrap/Type/Replication/Updated.hs
+++ b/src/lib/Rattletrap/Type/Replication/Updated.hs
@@ -7,7 +7,7 @@ import qualified Rattletrap.Schema as Schema
 import qualified Rattletrap.Type.Attribute as Attribute
 import qualified Rattletrap.Type.ClassAttributeMap as ClassAttributeMap
 import qualified Rattletrap.Type.CompressedWord as CompressedWord
-import qualified Rattletrap.Type.List as List
+import qualified Rattletrap.Type.List as RList
 import qualified Rattletrap.Type.Str as Str
 import qualified Rattletrap.Type.U32 as U32
 import qualified Rattletrap.Type.Version as Version
@@ -15,7 +15,7 @@ import qualified Rattletrap.Utility.Json as Json
 import qualified Rattletrap.Utility.Monad as Monad
 
 newtype Updated = Updated
-  { attributes :: List.List Attribute.Attribute
+  { attributes :: RList.List Attribute.Attribute
   }
   deriving (Eq, Show)
 
@@ -28,14 +28,14 @@ instance Json.ToJSON Updated where
 schema :: Schema.Schema
 schema =
   Schema.named "replication-updated" . Schema.json $
-    List.schema
+    RList.schema
       Attribute.schema
 
 bitPut :: Updated -> BitPut.BitPut
 bitPut x =
   foldMap
     (\y -> BitPut.bool True <> Attribute.bitPut y)
-    (List.toList $ attributes x)
+    (RList.toList $ attributes x)
     <> BitPut.bool False
 
 bitGet ::
@@ -46,7 +46,7 @@ bitGet ::
   CompressedWord.CompressedWord ->
   BitGet.BitGet Updated
 bitGet version buildVersion classes actors actor =
-  BitGet.label "Updated" . fmap Updated . List.untilM $ do
+  BitGet.label "Updated" . fmap Updated . RList.untilM $ do
     p <- BitGet.bool
     Monad.whenMaybe p $
       Attribute.bitGet version buildVersion classes actors actor


### PR DESCRIPTION
Closes https://github.com/tfausak/rattletrap/pull/292.

In future versions of GHC, `List.List` will be ambiguous because `Data.List` will start exporting `List` as a type alias for `[]`. Rather than using CPP to solve this problem, this PR uses `RList` as the alias for the internal list type. 

It might be a good idea to rename the type to something that doesn't collide with other names. Like perhaps `Arr` or `Vec` or something like that. 